### PR TITLE
Add with_iter.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2,7 +2,8 @@ from functools import partial, wraps
 from itertools import izip_longest, ifilter
 from recipes import *
 
-__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen']
+__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 
+           'with_iter']
 
 
 _marker = object()
@@ -207,3 +208,13 @@ def ilen(iterable):
 
     """
     return sum(1 for _ in iterable)
+
+def with_iter(iterable):
+    """Wrap an iterable in a with statement, so it closes when consumed.
+
+    >>> uplines = (line.upper() for line in with_iter(open("foo")))
+    >>> print('\n'.join(uplines))
+    """
+    with iterable:
+        for item in iterable:
+            yield item


### PR DESCRIPTION
- Wraps an iterable in a with statement, so it closes when consumed.

The idea is that you can, e.g., use a file in a generator expression, and the file will be closed when the generator is fully consumed (or closed or deleted). So, you can pass that generator to an async call, knowing the file will be closed at the appropriate time.

It works for any object which is both an iterable and a contextmanager.
