### PR TITLE
Modify unique_everseen to handle non-hashable elements.

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -233,15 +233,28 @@ def unique_everseen(iterable, key=None):
     seen = set()
     seen_add = seen.add
     if key is None:
-        for element in ifilterfalse(seen.__contains__, iterable):
-            seen_add(element)
+        for element in iterable:
+            try:
+                if element not in seen:
+                    seen_add(element)
+            except TypeError as e:
+                seen = list(seen)
+                seen_add = seen.append
+                if element not in seen:
+                    seen_add(element)
             yield element
     else:
         for element in iterable:
             k = key(element)
-            if k not in seen:
-                seen_add(k)
-                yield element
+            try:
+                if k not in seen:
+                    seen_add(k)
+            except TypeError as e:
+                seen = list(seen)
+                seen_add = seen.append
+                if k not in seen:
+                    seen_add(k)
+            yield element
 
 
 def unique_justseen(iterable, key=None):


### PR DESCRIPTION
- Try the set-based algorithm, but fall back to a list on a TypeError.
- This is less than 5% slower when everything is hashable, up to 10x slower
  (but still competitive with other non-hashing algorithms) in the worst case
  (all elements are non-hashable).

I'm not sure whether you want this, at least under this name, for two reasons.

First, although it's a drop-in replacement for the itertools docs recipe of the same name, it's not identical to it.

Second, it is almost 5% slower when everything is hashable—plus, there might conceivably be cases where being hashable is part of your preconditions, and you'd rather get an exception than have things silently work and take longer.

However, I think for general-purpose use, this is a big improvement.

See the thread that starts http://mail.python.org/pipermail/python-ideas/2012-November/017881.html for more details.
