### PR TITLE
Add iterate, from Haskell prelude.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2,7 +2,7 @@ from functools import partial, wraps
 from itertools import izip_longest, ifilter
 from recipes import *
 
-__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen']
+__all__ = ['chunked', 'first', 'peekable', 'collate', 'consumer', 'ilen', 'iterate']
 
 
 _marker = object()
@@ -207,3 +207,13 @@ def ilen(iterable):
 
     """
     return sum(1 for _ in iterable)
+
+def iterate(func, start):
+    """Return start, func(start), func(func(start)), ...
+
+    >>> list(islice(iterate(lambda x: 2*x, 1), 10))
+    [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+    """
+    while True:
+        yield start
+        start = func(start)


### PR DESCRIPTION
http://zvon.org/comp/r/ref-Haskell.html#Functions~Prelude.iterate

It seems a bit odd to not have iterate in the same place as the fold\* functions, but given that accumulate and reduce aren't in the same place, I think this goes here, while they go in more-functools (or an updated version of the old functional) or something.
