### PR TITLE
Add prepend recipe

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -110,6 +110,7 @@ These tools combine multiple iterables.
 .. autofunction:: dotproduct
 .. autofunction:: flatten
 .. autofunction:: roundrobin
+.. autofunction:: prepend
 
 
 Summarizing

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -33,6 +33,7 @@ __all__ = [
     'pairwise',
     'partition',
     'powerset',
+    'prepend',
     'quantify',
     'random_combination_with_replacement',
     'random_combination',
@@ -548,3 +549,17 @@ def nth_combination(iterable, r, index):
         result.append(pool[-1 - n])
 
     return tuple(result)
+
+
+def prepend(value, iterator):
+    """Yield *value*, followed by the elements in *iterator*.
+
+        >>> value = '0'
+        >>> iterator = ['1', '2', '3']
+        >>> list(prepend(value, iterator))
+        ['0', '1', '2', '3']
+
+    To prepend multiple values, see :func:`itertools.chain`.
+
+    """
+    return chain([value], iterator)

--- a/more_itertools/tests/test_recipes.py
+++ b/more_itertools/tests/test_recipes.py
@@ -589,3 +589,19 @@ class NthCombinationTests(TestCase):
         actual = mi.nth_combination(range(180), 4, 2000000)
         expected = (2, 12, 35, 126)
         self.assertEqual(actual, expected)
+
+
+class PrependTests(TestCase):
+    def test_basic(self):
+        value = 'a'
+        iterator = iter('bcdefg')
+        actual = list(mi.prepend(value, iterator))
+        expected = list('abcdefg')
+        self.assertEqual(actual, expected)
+
+    def test_multiple(self):
+        value = 'ab'
+        iterator = iter('cdefg')
+        actual = tuple(mi.prepend(value, iterator))
+        expected = ('ab',) + tuple('cdefg')
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
As of [recently](https://github.com/python/cpython/pull/6415), the official itertools recipes have `prepend()`.

I [rejected this previously](https://github.com/erikrose/more-itertools/pull/22#issuecomment-258646022) on account of it being less good than just using `chain()` directly, but we'll include it in `recipes.py` now.