### PR TITLE
Rsplit

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1148,7 +1148,7 @@ def _concatenate_slice(iterable, n=None):
     it = _aggregate_slice(iterable, lambda it: reduce(add, it), n)
     try:
         yield next(it)
-    except TypeError as e:  # nothing to aggregate
+    except TypeError:  # empty iterator
         pass
     else:
         yield from it

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1094,10 +1094,6 @@ def split_at(iterable, pred, maxsplit=-1, rsplit=False, keep_separator=False):
         >>> list(split_at(range(10), lambda n: n % 2 == 1,
         ...               maxsplit=2, rsplit=True, keep_separator=True))
         [[0, 1, 2, 3, 4, 5, 6], [7], [8], [9], []]
-
-        >>> list(split_at(range(0), lambda n: n % 2 == 1,
-        ...               maxsplit=2, rsplit=True, keep_separator=True))
-        []
     """
     def _split_at(iterable, pred, maxsplit, keep_separator):
         buf = []
@@ -1152,9 +1148,10 @@ def _concatenate_slice(iterable, n=None):
     it = _aggregate_slice(iterable, lambda it: reduce(add, it), n)
     try:
         yield next(it)
-    except TypeError:  # nothing to aggregate
+    except TypeError as e:  # nothing to aggregate
         pass
-    yield from it
+    else:
+        yield from it
 
 
 def _aggregate_slice(iterable, func, n=None):
@@ -1192,7 +1189,8 @@ def _aggregate_slice(iterable, func, n=None):
             n = total + n
 
     it = iter(iterable)
-    yield func(islice(it, n))
+    if n != 0:
+        yield func(islice(it, n))
     yield from it
 
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -27,6 +27,7 @@ from time import sleep
 from unittest import skipIf, TestCase
 
 import more_itertools as mi
+from more_itertools.more import _aggregate_slice
 
 
 def load_tests(loader, tests, ignore):
@@ -1110,6 +1111,34 @@ class SplitAtTests(TestCase):
         test_strs = ['', 'abcba', 'aaabbbcccddd', 'e']
         for s, delim, maxsplit in product(test_strs, 'abcd', range(-1, 4)):
             self.comp_with_str_split(s, delim, maxsplit)
+
+
+class AggregateSliceTests(TestCase):
+    def test(self):
+        def func(it):
+            return reduce(add, it, [])
+
+        for args, expected in [
+            ((([x] for x in range(5)), func), [[0, 1, 2, 3, 4]]),
+            ((([x] for x in range(5)), func, 0),
+             [[], [0], [1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, 1), [[0], [1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, 2), [[0, 1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, 3), [[0, 1, 2], [3], [4]]),
+            ((([x] for x in range(5)), func, 4), [[0, 1, 2, 3], [4]]),
+            ((([x] for x in range(5)), func, 5), [[0, 1, 2, 3, 4]]),
+            ((([x] for x in range(5)), func, 6), [[0, 1, 2, 3, 4]]),
+            ((([x] for x in range(5)), func, -1), [[0, 1, 2, 3], [4]]),
+            ((([x] for x in range(5)), func, -2), [[0, 1, 2], [3], [4]]),
+            ((([x] for x in range(5)), func, -3), [[0, 1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, -4), [[0], [1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, -5),
+             [[], [0], [1], [2], [3], [4]]),
+            ((([x] for x in range(5)), func, -6),
+             [[], [0], [1], [2], [3], [4]]),
+        ]:
+            actual = list(_aggregate_slice(*args))
+            self.assertEqual(actual, expected)
 
 
 class SplitBeforeTest(TestCase):


### PR DESCRIPTION
See #381
There where different options: a) use `rlocate`, b) try to insert the `rsplit` logic directly in the code or c) merge the first chunks to keep only the last chunks. Options a) and b) had a lot of edges cases, so I decided to:

1. create all the chunks;
2. merge all chunks excepted `maxsplit`.

I added two helper functions.

(I used the parameter name `rsplit`, but it is easy to change this).