### PR TITLE
Remove use of deprecate 'setup.py test' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install -U mypy; fi"
 
 script:
-    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' setup.py test"
+    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' -m unittest"
     - "flake8 ."
     - "sphinx-build -W -b html docs docs/_build/html"
     - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then mypy more_itertools; fi"

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -4,7 +4,7 @@ Testing
 
 To run install dependencies and run tests, use this command::
 
-    python setup.py test
+    python -m unittest
 
 Multiple Python Versions
 ========================

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     package_data={'more_itertools': ['py.typed', '*.pyi']},
     include_package_data=True,
     python_requires='>=3.5',
-    test_suite='tests',
     url='https://github.com/erikrose/more-itertools',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command and its
arguments are formally deprecated and should not be used. Tests are
still easy to run -- as before -- through tox or with the unittest
module.