### PR TITLE
Remove unnecessary --omit argument from coverage run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then pip install -U mypy; fi"
 
 script:
-    - "coverage run --include='more_itertools/*.py' --omit='more_itertools/tests/*' setup.py test"
+    - "coverage run --include='more_itertools/*.py' setup.py test"
     - "flake8 ."
     - "sphinx-build -W -b html docs docs/_build/html"
     - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then mypy more_itertools; fi"


### PR DESCRIPTION
The tests were moved out of the package in commit
4125f070e2b78aa2666185bee87be10184394d45. So there is no longer a reason
to omit them.