### PR TITLE
Add r to distinct_permutations

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -545,10 +545,13 @@ def one(iterable, too_short=None, too_long=None):
     return first_value
 
 
-def distinct_permutations(iterable):
+def distinct_permutations(iterable, r=None):
     """Yield successive distinct permutations of the elements in *iterable*.
 
         >>> sorted(distinct_permutations([1, 0, 1]))
+        [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
+
+        >>> sorted(distinct_permutations([1, 0, 1], r=3))
         [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
 
     Equivalent to ``set(permutations(iterable))``, except duplicates are not
@@ -562,29 +565,50 @@ def distinct_permutations(iterable):
     sequence.
 
     """
+    # When r is none, the output permutations are built up by inserting each
+    # element of the iterable at every possible position of the current list
+    # of permutations. The repeated elements are kept in (reverse) order:
+    # if e1 == e2 and e1 occurs before e2 in the iterable, then all
+    # permtuations with e1 before e2 are ignored.
+    if r is None:
+        permutations = [()]
+        for e in iterable:
+            new_perms = []
+            for perm in permutations:
+                for i in range(len(perm)):
+                    new_perms.append(perm[:i] + (e,) + perm[i:])
+                    if perm[i] == e:
+                        break
+                else:
+                    new_perms.append(perm + (e,))
+            permutations = new_perms
 
-    def make_new_permutations(pool, e):
-        """Internal helper function.
-        The output permutations are built up by adding element *e* to the
-        current *permutations* at every possible position.
-        The key idea is to keep repeated elements (reverse) ordered:
-        if e1 == e2 and e1 is before e2 in the iterable, then all permutations
-        with e1 before e2 are ignored.
+        return iter(permutations)
 
-        """
-        for perm in pool:
-            for j in range(len(perm)):
-                yield perm[:j] + (e,) + perm[j:]
-                if perm[j] == e:
-                    break
-            else:
-                yield perm + (e,)
+    # When r is not None, we use a recursive generator
+    def helper(abc, depth):
+        if depth:
+            depth -= 1
+            a, *bc = abc
+            for cb in helper(bc, depth):
+                yield (a, *cb)
+            for i, b in enumerate(bc):
+                if a == b:
+                    continue
+                a, bc[i] = b, a
+                for cb in helper(bc, depth):
+                    yield (a, *cb)
+        else:
+            yield abc
 
-    permutations = [()]
-    for e in iterable:
-        permutations = make_new_permutations(permutations, e)
-
-    return (tuple(t) for t in permutations)
+    sorted_items = sorted(iterable)
+    item_count = len(sorted_items)
+    if r == 0:
+        return iter([()])
+    if r > item_count:
+        return iter(())
+    initial_depth = r - 1 if (r == item_count) else r
+    return (res[:r] for res in helper(sorted_items, initial_depth))
 
 
 def intersperse(e, iterable, n=1):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -551,9 +551,6 @@ def distinct_permutations(iterable, r=None):
         >>> sorted(distinct_permutations([1, 0, 1]))
         [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
 
-        >>> sorted(distinct_permutations([1, 0, 1], r=3))
-        [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
-
     Equivalent to ``set(permutations(iterable))``, except duplicates are not
     generated and thrown away. For larger input sequences this is much more
     efficient.
@@ -563,6 +560,11 @@ def distinct_permutations(iterable, r=None):
     `n! / (x_1! * x_2! * ... * x_n!)`, where `n` is the total number of
     items input, and each `x_i` is the count of a distinct item in the input
     sequence.
+
+    If *r* is given, only the *r*-length permutations are yielded.
+
+        >>> sorted(distinct_permutations([1, 0, 1], r=3))
+        [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
 
     """
     # When r is none, the output permutations are built up by inserting each

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -526,6 +526,23 @@ class DistinctPermutationsTests(TestCase):
         ref_output = sorted(set(permutations(iterable)))
         self.assertEqual(test_output, ref_output)
 
+    def test_r(self):
+        for iterable, r in (
+            ('mississippi', 0),
+            ('mississippi', 1),
+            ('mississippi', 6),
+            ('mississippi', 7),
+            ([0, 1, 1, 0], 0),
+            ([0, 1, 1, 0], 1),
+            ([0, 1, 1, 0], 2),
+            ([0, 1, 1, 0], 3),
+            ([0, 1, 1, 0], 4),
+        ):
+            with self.subTest(iterable=iterable, r=r):
+                expected = sorted(set(permutations(iterable, r)))
+                actual = sorted(mi.distinct_permutations(iter(iterable), r))
+                self.assertEqual(actual, expected)
+
 
 class IlenTests(TestCase):
     def test_ilen(self):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -532,6 +532,7 @@ class DistinctPermutationsTests(TestCase):
             ('mississippi', 1),
             ('mississippi', 6),
             ('mississippi', 7),
+            ('mississippi', 12),
             ([0, 1, 1, 0], 0),
             ([0, 1, 1, 0], 1),
             ([0, 1, 1, 0], 2),


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/388, this PR adds an `r` parameter to `distinct_permutations`.

To preserve the optimizations from #259, this new code is only called if `r` is given.

CC: @SergBobrovsky