### PR TITLE
Fix spy to make returned iterable immutable

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -932,7 +932,7 @@ def spy(iterable, n=1):
     it = iter(iterable)
     head = take(n, it)
 
-    return head, chain(head, it)
+    return head.copy(), chain(head, it)
 
 
 def interleave(*iterables):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -933,6 +933,15 @@ class SpyTests(TestCase):
         self.assertEqual(head, [])
         self.assertEqual(list(new_iterable), ['a', 'b', 'c'])
 
+    def test_immutable(self):
+        original_iterable = iter('abcdefg')
+        head, new_iterable = mi.spy(original_iterable, 3)
+        head[0] = 'A'
+        self.assertEqual(head, ['A', 'b', 'c'])
+        self.assertEqual(
+            list(new_iterable), ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+        )
+
 
 class InterleaveTests(TestCase):
     def test_even(self):


### PR DESCRIPTION
`spy` returns an list and an iterable, part of which contains all
elements of the list. The problem was the iterable contained the
list within and changing the list changed the iterable.

This commit decouples the iterable from returned list and that
makes it immutable.

fixes #409