### PR TITLE
Run stubtest as part of the CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
     - "flake8 ."
     - "sphinx-build -W -b html docs docs/_build/html"
     - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then mypy more_itertools; fi"
+    - "if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then stubtest more_itertools.more more_itertools.recipes; fi"
 
 notifications:
     - email: false


### PR DESCRIPTION
`stubtest` is a tool that compares stub definitions to what it finds at runtime with introspection and reports back inconsistencies. It is packaged with `mypy` since version 0.770.
Adding this test to the Travis CI pipeline ensures there are no missing arguments in the stub file (e.g. `more_itertools.distinct_permutations is inconsistent, stub does not have argument "r"`), no extra arguments (e.g. ` more_itertools.more.distinct_permutations is inconsistent, runtime does not have argument "extra"`), no missing defaults (`more_itertools.more.distinct_permutations is inconsistent, runtime argument "r" has a default value but stub argument does not`), etc.
`stubtest` does **not** check whether the functions are correctly typed based on their implementation.

For instance, [Travis CI Job #1269.4](https://travis-ci.org/github/more-itertools/more-itertools/jobs/668583567) is failing with the following error:

```
error: more_itertools.more.distinct_permutations is inconsistent, stub does not have argument "r"
Stub: at line 81
def [_T] (iterable: typing.Iterable[_T`-1]) -> typing.Iterator[builtins.tuple[_T`-1]]
Runtime: at line 548 in file /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/more_itertools/more.py
def (iterable, r=None)
```

This test passes since #414 has been merged to master ([Travis CI Job #1272](https://travis-ci.org/github/more-itertools/more-itertools/builds/668830235)).