### PR TITLE
Adding an aggregator function

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -27,6 +27,7 @@ from .recipes import consume, flatten, powerset, take, unique_everseen
 
 __all__ = [
     'adjacent',
+    "aggregator",
     'always_iterable',
     'always_reversible',
     'bucket',
@@ -99,6 +100,31 @@ __all__ = [
 ]
 
 _marker = object()
+
+def aggregator(aggregator_func):
+    """Combines the output of a generator with *aggregator_func*
+
+        >>> @aggregator(" ".join)
+        ... def string_yielder():
+        ...     yield "Hello"
+        ...     yield "World!"
+        "Hello World!
+
+    Allows the usage of yields in the code without needing to convert to list allowing
+    for more expressive and cleaner code instead of ``list.append``
+    This is particularly nice when interfacing with code that recieves data in a
+    paginated fashion but you'd like to return a ``pd.DataFrame`` or ``np.array``
+
+    This can also be chained
+    """
+    def wrapper(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            return aggregator_func(func(*args, **kwargs))
+
+        return inner
+
+    return wrapper
 
 
 def chunked(iterable, n):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3573,3 +3573,65 @@ class SampleTests(TestCase):
 
         # The observed largest difference in 10,000 simulations was 4.337999
         self.assertTrue(difference_in_means < 4.4)
+
+
+class AggregatorTests(TestCase):
+
+    def test_strjoin(self):
+        @mi.aggregator(" ".join)
+        def hello_world():
+            yield "Hello"
+            yield "World"
+
+        self.assertEqual(hello_world(), "Hello World")
+
+    def test_str_join_on_list(self):
+        @mi.aggregator(" ".join)
+        def hello_world():
+            return ["Hello", "World"]
+
+        self.assertEqual(hello_world(), "Hello World")
+
+    def test_listify(self):
+        @mi.aggregator(list)
+        def hello_world():
+            yield "Hello"
+            yield "World"
+
+        self.assertEqual(hello_world(), ["Hello", "World"])
+
+    def test_chained(self):
+        # test, not a recommended way to do things!
+        @mi.aggregator(tuple)
+        @mi.aggregator(chain.from_iterable)
+        def number_lists():
+            yield [1, 2, 3]
+            yield [4, 5, 6]
+
+        self.assertEqual(number_lists(), (1, 2, 3, 4, 5, 6))
+
+    def test_chained_2(self):
+        # indicates an apply_each might be useful?
+        @mi.aggregator(".".join)
+        @mi.aggregator(lambda x: map(str, x))
+        @mi.aggregator(chain.from_iterable)
+        def number_lists():
+            yield [1, 2, 3]
+            yield [4, 5, 6]
+
+        self.assertEqual(number_lists(), "1.2.3.4.5.6")
+
+    def test_conversion(self):
+        # test, not a recommended way to do things!
+        @mi.aggregator(set)
+        def number_set():
+            return range(7)
+
+        self.assertEqual(number_set(), {0, 1, 2, 3, 4, 5, 6})
+
+    def test_reduction(self):
+        @mi.aggregator(sum)
+        def summer():
+            return range(7)
+
+        self.assertEqual(summer(), 21)


### PR DESCRIPTION
When writing code, I tend to prefer using `yield's` and `yield from` since it means I don't have to maintain my own list, append and then join. This does push the aggregation to the calling code which can be annoying when it's the same thing every time and pushes the complexity/boilerplate to the caller. So I've written a wrapper that does this for me.

for example

```python

def hello_world():
    string_list = []
    string_list.append("Hello")
    string_list.append("World")
    return " ".join(string_list)

```
is now
```python
@mi.aggregator(" ".join)
def string_yielder():
    yield "Hello"
    yield "World!"
```

This also comes in use when I have to hit a db/external resource in a paginated way but need to return a `np.array` or `pd.DataFrame`, again I can just yield and then the aggregator does the work, keeping the code clean and very readable.

I'm not in love with the name and more than happy to update the doc + any other things if you have some suggestions - this is sort of a minimal PR to gauge interest before I put in more effort to get it release worthy.