### PR TITLE
Check lengths of iterables in zip_equal for better speed and error message

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import Counter, defaultdict, deque, abc
-from collections.abc import Sequence, Sized
+from collections.abc import Sequence
 from functools import partial, wraps
 from heapq import merge, heapify, heapreplace, heappop
 from itertools import (
@@ -1423,21 +1423,22 @@ def zip_equal(*iterables):
     the others.
 
     """
-    if all(isinstance(it, Sized) for it in iterables):
+    try:
         lengths = list(map(len, iterables))
-        if len(set(lengths)) == 1:
-            return zip(*iterables)
-
-        if len(iterables) <= 10:
-            description = str(lengths)
-        else:
-            description = "from {} to {}".format(min(lengths), max(lengths))
-
-        raise UnequalIterablesError(
-            "Iterables have different lengths: " + description
-        )
-    else:
+    except TypeError:
         return _zip_equal_generator(iterables)
+
+    if len(set(lengths)) == 1:
+        return zip(*iterables)
+
+    if len(iterables) <= 10:
+        description = str(lengths)
+    else:
+        description = "from {} to {}".format(min(lengths), max(lengths))
+
+    raise UnequalIterablesError(
+        "Iterables have different lengths: " + description
+    )
 
 
 def _zip_equal_generator(iterables):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import Counter, defaultdict, deque, abc
-from collections.abc import Sequence
+from collections.abc import Sequence, Sized
 from functools import partial, wraps
 from heapq import merge, heapify, heapreplace, heappop
 from itertools import (
@@ -1423,6 +1423,24 @@ def zip_equal(*iterables):
     the others.
 
     """
+    if all(isinstance(it, Sized) for it in iterables):
+        lengths = list(map(len, iterables))
+        if len(set(lengths)) == 1:
+            return zip(*iterables)
+
+        if len(iterables) <= 10:
+            description = str(lengths)
+        else:
+            description = "from {} to {}".format(min(lengths), max(lengths))
+
+        raise UnequalIterablesError(
+            "Iterables have different lengths: " + description
+        )
+    else:
+        return _zip_equal_generator(iterables)
+
+
+def _zip_equal_generator(iterables):
     for combo in zip_longest(*iterables, fillvalue=_marker):
         for val in combo:
             if val is _marker:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1678,21 +1678,35 @@ class ZipEqualTest(TestCase):
     def test_unequal(self):
         short = [0, 1]
         long = [2, 3, 4]
-        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: [2, 3]"):
+        with self.assertRaises(
+                mi.UnequalIterablesError,
+                msg="Iterables have different lengths: [2, 3]",
+        ):
             list(mi.zip_equal(short, long))
 
-        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: [3, 2]"):
+        with self.assertRaises(
+                mi.UnequalIterablesError,
+                msg="Iterables have different lengths: [3, 2]",
+        ):
             list(mi.zip_equal(long, short))
 
-        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths"):
+        with self.assertRaises(
+                mi.UnequalIterablesError,
+                msg="Iterables have different lengths",
+        ):
             list(mi.zip_equal(iter(short), iter(long)))
 
-        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths"):
+        with self.assertRaises(
+                mi.UnequalIterablesError,
+                msg="Iterables have different lengths",
+        ):
             list(mi.zip_equal(iter(long), iter(short)))
-        
-        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: from 10 to 99"):
-            list(mi.zip_equal(*[range(n) for n in range(10, 100)]))
 
+        with self.assertRaises(
+                mi.UnequalIterablesError,
+                msg="Iterables have different lengths: from 10 to 99",
+        ):
+            list(mi.zip_equal(*[range(n) for n in range(10, 100)]))
 
 
 class ZipOffsetTest(TestCase):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1668,19 +1668,31 @@ class ZipEqualTest(TestCase):
     """Tests for ``zip_equal()``"""
 
     def test_equal(self):
-        iterables = [0, 1, 2], [2, 3, 4]
-        actual = list(mi.zip_equal(*iterables))
-        expected = [(0, 2), (1, 3), (2, 4)]
-        self.assertEqual(actual, expected)
+        lists = [0, 1, 2], [2, 3, 4]
+
+        for iterables in [lists, map(iter, lists)]:
+            actual = list(mi.zip_equal(*iterables))
+            expected = [(0, 2), (1, 3), (2, 4)]
+            self.assertEqual(actual, expected)
 
     def test_unequal(self):
         short = [0, 1]
         long = [2, 3, 4]
-        with self.assertRaises(mi.UnequalIterablesError):
+        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: [2, 3]"):
             list(mi.zip_equal(short, long))
 
-        with self.assertRaises(mi.UnequalIterablesError):
+        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: [3, 2]"):
             list(mi.zip_equal(long, short))
+
+        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths"):
+            list(mi.zip_equal(iter(short), iter(long)))
+
+        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths"):
+            list(mi.zip_equal(iter(long), iter(short)))
+        
+        with self.assertRaises(mi.UnequalIterablesError, msg="Iterables have different lengths: from 10 to 99"):
+            list(mi.zip_equal(*[range(n) for n in range(10, 100)]))
+
 
 
 class ZipOffsetTest(TestCase):


### PR DESCRIPTION
Hi!

This PR checks (when possible) the lengths of the iterables passed to `zip_equal`. This allows it to give a more informative error message for differing lengths, allowing easier debugging. It also means it can just defer to `zip` without iterating in Python space, which is significantly faster. Here's a benchmark comparing zip_equal in master with zip:

 ```python
import timeit
from collections import deque
from more_itertools import zip_equal

x1 = list(range(1000))
x2 = list(range(1000, 2000))


def my_timeit(stmt):
    print(timeit.repeat(stmt, globals=globals(), number=10000, repeat=3))


def consume(iterator):
    deque(iterator, maxlen=0)


my_timeit("consume(zip(x1, x2))")
my_timeit("consume(zip_equal(x1, x2))")
```

Output:

```
[0.151994071, 0.16300702100000003, 0.14365304500000003]
[2.094478611, 2.043564243, 2.0213984409999997]
```

So zip is about 13 times faster, and this PR takes advantage of that for the common case of zipping lists or other sequences.