### PR TITLE
Fix exception causes

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -153,7 +153,7 @@ def first(iterable, default=_marker):
     """
     try:
         return next(iter(iterable))
-    except StopIteration:
+    except StopIteration as e:
         # I'm on the edge about raising ValueError instead of StopIteration. At
         # the moment, ValueError wins, because the caller could conceivably
         # want to do something different with flow control when I raise the
@@ -162,7 +162,7 @@ def first(iterable, default=_marker):
             raise ValueError(
                 'first() was called on an empty iterable, and no '
                 'default value was provided.'
-            )
+            ) from e
         return default
 
 
@@ -185,12 +185,12 @@ def last(iterable, default=_marker):
         except (TypeError, AttributeError, KeyError):
             # If not slice-able, iterate entirely using length-1 deque
             return deque(iterable, maxlen=1)[0]
-    except IndexError:  # If the iterable was empty
+    except IndexError as e:  # If the iterable was empty
         if default is _marker:
             raise ValueError(
                 'last() was called on an empty iterable, and no '
                 'default value was provided.'
-            )
+            ) from e
         return default
 
 
@@ -539,8 +539,8 @@ def one(iterable, too_short=None, too_long=None):
 
     try:
         first_value = next(it)
-    except StopIteration:
-        raise too_short or ValueError('too few items in iterable (expected 1)')
+    except StopIteration as e:
+        raise (too_short or ValueError('too few items in iterable (expected 1)')) from e
 
     try:
         second_value = next(it)


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 