### PR TITLE
Improve distinct_permutations's docstring example for parameter r

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -577,8 +577,10 @@ def distinct_permutations(iterable, r=None):
 
     If *r* is given, only the *r*-length permutations are yielded.
 
-        >>> sorted(distinct_permutations([1, 0, 1], r=3))
-        [(0, 1, 1), (1, 0, 1), (1, 1, 0)]
+        >>> sorted(distinct_permutations([1, 0, 1], r=2))
+        [(0, 1), (1, 0), (1, 1)]
+        >>> sorted(distinct_permutations(range(3), r=2))
+        [(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
 
     """
     # Algorithm: https://w.wiki/Qai


### PR DESCRIPTION
The current example illustrating the parameter `r` of `distinct_permutations` is somewhat uninformative as it passes `r=3`, which happens to be the length of `iterable`, effectively making it identical - yet more verbose - to the example above (where `r` isn't passed).

Instead, we propose 2 illustrations, both using `r < len(iterable)`: one where the elements of `iterable` are unique and one where they are not. This should emphasize the effect of both `r` itself (by comparison with the example above) and of the presence of duplicates in `iterable`.