### PR TITLE
fix typo in more.partitions docstring

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2890,7 +2890,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
 
 def partitions(iterable):
-    """Yield all possible order-perserving partitions of *iterable*.
+    """Yield all possible order-preserving partitions of *iterable*.
 
     >>> iterable = 'abc'
     >>> for part in partitions(iterable):


### PR DESCRIPTION
Noticed this while reading the documentation, I checked it's the only occurrence though.