### PR TITLE
More thorough tests for distinct_combinations

### DIFF
--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3732,8 +3732,10 @@ class DistinctCombinationsTests(TestCase):
         ]:
             for r in range(len(iterable)):
                 with self.subTest(iterable=iterable, r=r):
-                    actual = sorted(mi.distinct_combinations(iterable, r))
-                    expected = sorted(set(combinations(iterable, r)))
+                    actual = list(mi.distinct_combinations(iterable, r))
+                    expected = list(
+                        mi.unique_everseen(combinations(iterable, r))
+                    )
                     self.assertEqual(actual, expected)
 
     def test_negative(self):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3723,20 +3723,18 @@ class IchunkedTests(TestCase):
 
 class DistinctCombinationsTests(TestCase):
     def test_basic(self):
-        iterable = (1, 2, 2, 3, 3, 3)
-        for r in range(len(iterable)):
-            with self.subTest(r=r):
-                actual = sorted(mi.distinct_combinations(iterable, r))
-                expected = sorted(set(combinations(iterable, r)))
-                self.assertEqual(actual, expected)
-
-    def test_distinct(self):
-        iterable = list(range(6))
-        for r in range(len(iterable)):
-            with self.subTest(r=r):
-                actual = list(mi.distinct_combinations(iterable, r))
-                expected = list(combinations(iterable, r))
-                self.assertEqual(actual, expected)
+        for iterable in [
+            (1, 2, 2, 3, 3, 3),  # In order
+            range(6),  # All distinct
+            'abbccc',  # Not numbers
+            'cccbba',  # Backward
+            'mississippi',  # No particular order
+        ]:
+            for r in range(len(iterable)):
+                with self.subTest(iterable=iterable, r=r):
+                    actual = sorted(mi.distinct_combinations(iterable, r))
+                    expected = sorted(set(combinations(iterable, r)))
+                    self.assertEqual(actual, expected)
 
     def test_negative(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When looking at #451, I found that the test suite doesn't exercise `distinct_combinations` very thoroughly. This PR adds tests to ensure (a) lexicographic ordering, and (b) inputs with different types of sorting.