### PR TITLE
Let last() use reversed()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 import warnings
 
 from collections import Counter, defaultdict, deque, abc
-from collections.abc import Reversible, Sequence
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
 from heapq import merge, heapify, heapreplace, heappop
@@ -23,7 +23,7 @@ from math import exp, floor, log
 from queue import Empty, Queue
 from random import random, randrange, uniform
 from operator import itemgetter, sub, gt, lt
-from sys import maxsize
+from sys import hexversion, maxsize
 from time import monotonic
 
 from .recipes import (
@@ -182,7 +182,8 @@ def last(iterable, default=_marker):
     try:
         if isinstance(iterable, Sequence):
             return iterable[-1]
-        elif isinstance(iterable, Reversible):
+        # Work around https://bugs.python.org/issue38525
+        elif hasattr(iterable, '__reversed__') and (hexversion != 0x030800F0):
             return next(reversed(iterable))
         else:
             return deque(iterable, maxlen=1)[-1]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -180,19 +180,25 @@ def last(iterable, default=_marker):
     raise ``ValueError``.
     """
     try:
+        # If the iterable is reversible, reverse it and return the first item.
+        return next(reversed(iterable))
+    except TypeError:
+        # If it's not reversible, feed it into a length-1 deque and return
+        # the last item.
         try:
-            # Try to access the last item directly
-            return iterable[-1]
-        except (TypeError, AttributeError, KeyError):
-            # If not slice-able, iterate entirely using length-1 deque
-            return deque(iterable, maxlen=1)[0]
-    except IndexError as e:  # If the iterable was empty
-        if default is _marker:
-            raise ValueError(
-                'last() was called on an empty iterable, and no '
-                'default value was provided.'
-            ) from e
-        return default
+            return deque(iterable, maxlen=1)[-1]
+        except IndexError:
+            pass
+    except StopIteration:
+        pass
+
+    # The iterable was empty.
+    if default is _marker:
+        raise ValueError(
+            'last() was called on an empty iterable, and no default value was '
+            'provided.'
+        )
+    return default
 
 
 def nth_or_last(iterable, n, default=_marker):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,7 @@
 import warnings
 
 from collections import Counter, defaultdict, deque, abc
-from collections.abc import Sequence
+from collections.abc import Reversible, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
 from heapq import merge, heapify, heapreplace, heappop
@@ -180,25 +180,19 @@ def last(iterable, default=_marker):
     raise ``ValueError``.
     """
     try:
-        # If the iterable is reversible, reverse it and return the first item.
-        return next(reversed(iterable))
-    except TypeError:
-        # If it's not reversible, feed it into a length-1 deque and return
-        # the last item.
-        try:
+        if isinstance(iterable, Sequence):
+            return iterable[-1]
+        elif isinstance(iterable, Reversible):
+            return next(reversed(iterable))
+        else:
             return deque(iterable, maxlen=1)[-1]
-        except IndexError:
-            pass
-    except StopIteration:
-        pass
-
-    # The iterable was empty.
-    if default is _marker:
-        raise ValueError(
-            'last() was called on an empty iterable, and no default value was '
-            'provided.'
-        )
-    return default
+    except (IndexError, TypeError, StopIteration):
+        if default is _marker:
+            raise ValueError(
+                'last() was called on an empty iterable, and no default was '
+                'provided.'
+            )
+        return default
 
 
 def nth_or_last(iterable, n, default=_marker):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -157,6 +157,7 @@ class LastTests(TestCase):
             (iter(range(1)), 0),
             (IterOnlyRange(5), 4),
             ({n: str(n) for n in range(5)}, 4),
+            ({0: '0', -1: '-1', 2: '-2'}, 2),
         ]:
             with self.subTest(iterable=iterable):
                 self.assertEqual(mi.last(iterable), expected)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -150,15 +150,19 @@ class IterOnlyRange:
 
 class LastTests(TestCase):
     def test_basic(self):
-        for iterable, expected in [
+        cases = [
             (range(4), 3),
             (iter(range(4)), 3),
             (range(1), 0),
             (iter(range(1)), 0),
             (IterOnlyRange(5), 4),
             ({n: str(n) for n in range(5)}, 4),
-            ({0: '0', -1: '-1', 2: '-2'}, 2),
-        ]:
+        ]
+        # Versions below 3.6.0 don't have ordered dicts
+        if version_info >= (3, 6, 0):
+            cases.append(({0: '0', -1: '-1', 2: '-2'}, 2))
+
+        for iterable, expected in cases:
             with self.subTest(iterable=iterable):
                 self.assertEqual(mi.last(iterable), expected)
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -156,6 +156,7 @@ class LastTests(TestCase):
             (range(1), 0),
             (iter(range(1)), 0),
             (IterOnlyRange(5), 4),
+            ({n: str(n) for n in range(5)}, 4),
         ]:
             with self.subTest(iterable=iterable):
                 self.assertEqual(mi.last(iterable), expected)
@@ -164,6 +165,7 @@ class LastTests(TestCase):
         for iterable, default, expected in [
             (range(1), None, 0),
             ([], None, None),
+            ({}, None, None),
             (iter([]), None, None),
         ]:
             with self.subTest(args=(iterable, default)):
@@ -172,17 +174,8 @@ class LastTests(TestCase):
     def test_empty(self):
         for iterable in ([], iter(range(0))):
             with self.subTest(iterable=iterable):
-                try:
+                with self.assertRaises(ValueError):
                     mi.last(iterable)
-                except ValueError:
-                    formatted_exc = format_exc()
-                    self.assertIn('IndexError', formatted_exc)
-                    self.assertIn(
-                        'The above exception was the direct cause',
-                        formatted_exc,
-                    )
-                else:
-                    self.fail()
 
 
 class NthOrLastTests(TestCase):


### PR DESCRIPTION
This PR updates `last()` such that it:
* Tries to access iterable's last (`[-1]`) item directly
*  If that doesn't work, tries to reverse the iterable and return its first item
* If that doesn't work, feeds the iterable into a length-1 deque and returns the only item

Closes https://github.com/more-itertools/more-itertools/issues/453.