### PR TITLE
Added pitchfork partitioning

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,7 +62,6 @@ These tools yield windows of items from an iterable.
 .. autofunction:: substrings
 .. autofunction:: substrings_indexes
 .. autofunction:: stagger
-.. autofunction:: pitchforked
 
 ----
 
@@ -198,6 +197,7 @@ These tools yield combinatorial arrangements of items from iterables.
 .. autofunction:: circular_shifts
 .. autofunction:: partitions
 .. autofunction:: set_partitions
+.. autofunction:: pitchforked
 
 ----
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,6 +62,7 @@ These tools yield windows of items from an iterable.
 .. autofunction:: substrings
 .. autofunction:: substrings_indexes
 .. autofunction:: stagger
+.. autofunction:: pitchforked
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -110,6 +110,7 @@ __all__ = [
     'UnequalIterablesError',
     'zip_equal',
     'zip_offset',
+    'pitchforked'
 ]
 
 _marker = object()
@@ -3383,3 +3384,66 @@ class callback_iter:
                 remaining.append(item)
         q.join()
         yield from remaining
+
+
+def pitchforked(seq, n=1):
+    """Splits the iterable into three pieces, with the middle piece of width *n* (the width of the pitchfork). Returns the prefix, middle and the suffix. Similar to :func:`windowed`, but allows reconstruction of the full sequence from each split.
+
+    >>> for p in pitchforked('ABCDEF', 2):
+    ...     print(*map(lambda x: ''.join(x),p))
+     AB CDEF
+    A BC DEF
+    AB CD EF
+    ABC DE F
+    ABCD EF 
+
+    To obtain every partitioning of a sequence, use :func:`chain` and :func:`map` to iterate over all possible partitioning lengths in one go:
+
+    >>> from itertools import chain
+    >>> from functools import partial
+    >>> every_pitchfork = lambda seq: chain(*map(
+    ...     partial(pitchforked,seq),range(len(seq))))
+    >>> sequence = 'ABCDE'
+    >>> for p in every_pitchfork(sequence):
+    ...     print(*map(lambda x: ''.join(x),p))
+      ABCDE
+    A  BCDE
+    AB  CDE
+    ABC  DE
+    ABCD  E
+    ABCDE  
+     A BCDE
+    A B CDE
+    AB C DE
+    ABC D E
+    ABCD E 
+     AB CDE
+    A BC DE
+    AB CD E
+    ABC DE 
+     ABC DE
+    A BCD E
+    AB CDE 
+     ABCD E
+    A BCDE 
+
+    A nested lambda function can also be used instead of :func:`partial`:
+
+    >>> from itertools import chain
+    >>> every_pitchfork = lambda seq: chain(*map(
+    ...     lambda n: pitchforked(seq,n),range(len(seq))))
+    """
+    if n < 0:
+        raise ValueError('n must be >= 0')
+    if n > len(seq):
+        raise ValueError('n must be <= len(seq)')
+    
+    prefix, hay, suffix = deque(), deque(), deque(seq)
+    for _ in range(n):
+        hay.append(suffix.popleft())
+    yield tuple(prefix), tuple(hay), tuple(suffix)
+
+    for _ in range(len(suffix)):
+        hay.append(suffix.popleft())
+        prefix.append(hay.popleft())
+        yield tuple(prefix), tuple(hay), tuple(suffix)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3995,3 +3995,63 @@ class CallbackIterTests(TestCase):
 
             with self.assertRaises(ValueError):
                 it.result
+
+
+class PitchforkedTests(TestCase):
+    """Tests for ``pitchforked()``"""
+
+    def test_basic(self):
+        actual = list(mi.pitchforked([1, 2, 3, 4, 5], 3))
+        expected = [
+            ((), (1, 2, 3), (4, 5)),
+            ((1,), (2, 3, 4), (5,)),
+            ((1, 2), (3, 4, 5), ())
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_zero_length(self):
+        """
+        Length 0 partitions
+        """
+        actual = list(mi.pitchforked([1, 2, 3], 0))
+        expected = [
+            ((), (), (1, 2, 3)),
+            ((1,), (), (2, 3)),
+            ((1, 2), (), (3,)),
+            ((1, 2, 3), (), ())
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_wrong_length(self):
+        """
+        Check that ValueError is raised for invalid values of n
+        """
+        seq = [1,2,3,4,5]
+        for n in (-10,-1,len(seq)+1,len(seq)+10):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    list(mi.pitchforked(seq, n))
+
+    def test_every_pitchfork(self):
+        """
+        Split a sequence into every possible partitioning thereof
+        """
+        every_pitchfork = lambda seq: chain(*map(
+            partial(mi.pitchforked,seq),range(len(seq))))
+
+        seq = 'ABC'
+        actual = list(every_pitchfork(seq))
+        expected = [
+            ((), (), ('A', 'B', 'C')),
+            (('A',), (), ('B', 'C')),
+            (('A', 'B'), (), ('C',)),
+            (('A', 'B', 'C'), (), ()),
+            ((), ('A',), ('B', 'C')),
+            (('A',), ('B',), ('C',)),
+            (('A', 'B'), ('C',), ()),
+            ((), ('A', 'B'), ('C',)),
+            (('A',), ('B', 'C'), ())
+        ]
+        
+        self.assertEqual(actual, expected)
+


### PR DESCRIPTION
I found myself in need of this functionality recently, and I couldn't find an appropriate `more_itertools` solution, so I thought I'll submit what I've come up with.

The idea is to be able to partition a sequence into three segments: the prefix, the middle part (which, in lack of a better name I've called `hay`) and the suffix. `pitchfork` yields all such splits. From the doctoring, this is a pitchfork partition of width two:

    >>> for p in pitchforked('ABCDEF', 2):
    ...     print(*map(lambda x: ''.join(x),p))
     AB CDEF
    A BC DEF
    AB CD EF
    ABC DE F
    ABCD EF 

The reason `windowed` doesn't cut it, is because I want to be able to construct the entire sequence from the parts on each iteration.

I've done my best to add it to the documentation correctly, and add tests (which all pass).

Hope you like it. 🙂
