### PR TITLE
docs: Fix simple typo, thankjs -> thanks

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -61,7 +61,7 @@ Version History
     * The :func:`spy` implementation was improved (thanks to has2k1)
 
 * Other changes
-    * Type stubs are now tested with ``stubtest`` (thankjs to ilai-deutel)
+    * Type stubs are now tested with ``stubtest`` (thanks to ilai-deutel)
     * Tests now run with ``python -m unittest`` instead of ``python setup.py test`` (thanks to jdufresne)
 
 8.2.0


### PR DESCRIPTION
There is a small typo in docs/versions.rst.

Should read `thanks` rather than `thankjs`.

