### PR TITLE
Drop 3.5 testing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9-dev, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9-dev, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,17 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9-dev, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9.0-rc.2, pypy3]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
-      if: "!endsWith(matrix.python-version, '-dev')"
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: deadsnakes/action@v1.0.0
-      if: endsWith(matrix.python-version, '-dev')
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}
+envlist = py{36,37,38}
 
 [testenv]
 commands = {envpython} -m unittest -v {posargs}


### PR DESCRIPTION
Python 3.5 has reached its end of life. This PR removes it from the testing matrix in GitHub Actions. It also switches to the GitHub-provided version of Python 3.9 for testing.