### PR TITLE
Simplify unique_everseen

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -386,12 +386,13 @@ def unique_everseen(iterable, key=None):
     ``key=lambda x: frozenset(x.items())`` can be used.
 
     """
+    key = key if key is not None else lambda x: x
     seenset = set()
     seenset_add = seenset.add
     seenlist = []
     seenlist_add = seenlist.append
-    iterable, keys = tee(iterable)
-    for element, k in zip(iterable, map(key, keys) if key else keys):
+    for element in iterable:
+        k = key(element)
         try:
             if k not in seenset:
                 seenset_add(k)


### PR DESCRIPTION
Further simplifies #326.

This PR uses this implementation:
```python
def new_unique_everseen_1(iterable, key=None):
    key = key if key is not None else lambda x: x
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append
    for element in iterable:
        k = key(element)
        try:
            if k not in seenset:
                seenset_add(k)
                yield element
        except TypeError:
            if k not in seenlist:
                seenlist_add(k)
                yield element
```
I thought it would have been faster than the current because of removing the whole `tee` and `zip` machinery but apparently not (see performance results below).


The alternatives I tried are as follows:

```python
from more_itertools import consume, unique_everseen


def old_unique_everseen(iterable, key=None):
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append
    if key is not None:
        for element in iterable:
            k = key(element)
            try:
                if k not in seenset:
                    seenset_add(k)
                    yield element
            except TypeError:
                if k not in seenlist:
                    seenlist_add(k)
                    yield element
    else:
        for element in iterable:
            try:
                if element not in seenset:
                    seenset_add(element)
                    yield element
            except TypeError:
                if element not in seenlist:
                    seenlist_add(element)
                    yield element


def new_unique_everseen_1(iterable, key=None):
    key = key if key is not None else lambda x: x
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append
    for element in iterable:
        k = key(element)
        try:
            if k not in seenset:
                seenset_add(k)
                yield element
        except TypeError:
            if k not in seenlist:
                seenlist_add(k)
                yield element


_ = [
    "def inner():",
    "    for element in iterable:",
    "        k = key(element)",
    "        try:",
    "            if k not in seenset:",
    "                seenset_add(k)",
    "                yield element",
    "        except TypeError:",
    "            if k not in seenlist:",
    "                seenlist_add(k)",
    "                yield element",
]
_code_with_key = compile("\n".join(_), f"{__file__}-unique_everseen", mode="single")
_[2] = "        k = element"
_code_without_key = compile("\n".join(_), f"{__file__}-unique_everseen", mode="single")
del _


def new_unique_everseen_2(iterable, key=None):
    seenset = set()
    seenset_add = seenset.add
    seenlist = []
    seenlist_add = seenlist.append

    exec(_code_with_key if key is not None else _code_without_key, locals())
    return locals()["inner"]()
```

The second one is a bit overkill in that it tries to avoid code duplication while also removing the key call entirely if there is no key.

But they all perform pretty much equivalently:

- With no key:
  ![graph (no key)](https://user-images.githubusercontent.com/18049056/102470770-ac796700-4054-11eb-8279-7c86cb1d0139.png)
   The peak is an outlier and probably has nothing to do with the performance itself.

- With `str` as key:
   ![graph (str as key)](https://user-images.githubusercontent.com/18049056/102470887-cf0b8000-4054-11eb-9a1d-8e0d0aae8e3d.png)

I'm guessing that the generator/iterator machinery is overshadowing any performance improvements.

Benchmarking code:

<details>

```python
import pickle
import random

import matplotlib.pyplot as plt
import perfplot

from more_itertools import consume

# [...] (definitions as shown above)


random.seed(2020)
funcs = (
    unique_everseen,
    old_unique_everseen,
    new_unique_everseen_1,
    new_unique_everseen_2
)

for i, key in enumerate((None, str)):
    benchmarks = perfplot.bench(
        setup=lambda n: random.sample(range(10_000), n),
        kernels=[lambda iterable: consume(func(iterable, key=key)) for func in funcs],
        labels=[f.__name__ for f in funcs],
        n_range=range(1_000, 10_000, 500),
        equality_check=None,
        show_progress=True,
    )

    with open(f"benchmarks-{i}.pickle", "wb") as f:
        pickle.dump(benchmarks, f)

    benchmarks.plot(relative_to=0)
    plt.tight_layout()
    plt.savefig(f"graph-{i}.png")
    plt.show()
```

</details>