### PR TITLE
Fix split_before for an empty collections.

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1235,7 +1235,8 @@ def split_before(iterable, pred, maxsplit=-1):
             buf = []
             maxsplit -= 1
         buf.append(item)
-    yield buf
+    if buf:
+        yield buf
 
 
 def split_after(iterable, pred, maxsplit=-1):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1238,6 +1238,11 @@ class SplitBeforeTest(TestCase):
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
 
+    def test_empty_collection(self):
+        actual = list(mi.split_before([], lambda c: bool(c)))
+        expected = []
+        self.assertEqual(actual, expected)
+
     def test_max_split(self):
         for args, expected in [
             (


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#508

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
If the function `split_before` gets an empty collection it will return an empty iterator.
```python
>>> list(split_before([], pred=lambda x: bool(x)) ) 
[]
```