### PR TITLE
Add a DeprecationWarning for 3.10+

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install -U coverage flake8
+        pip install -U coverage flake8 wheel
     - name: Run tests
       run: |
         coverage run --include="more_itertools/*.py" -m unittest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9.0, 3.10.0-alpha.4, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9.0, 3.10.0-alpha.6, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1490,6 +1490,15 @@ class UnequalIterablesError(ValueError):
         super().__init__(msg)
 
 
+
+def _zip_equal_generator(iterables):
+    for combo in zip_longest(*iterables, fillvalue=_marker):
+        for val in combo:
+            if val is _marker:
+                raise UnequalIterablesError()
+        yield combo
+
+
 def zip_equal(*iterables):
     """``zip`` the input *iterables* together, but raise
     ``UnequalIterablesError`` if they aren't all the same length.
@@ -1508,6 +1517,15 @@ def zip_equal(*iterables):
         lengths
 
     """
+    if hexversion >= 0x30a00a6:
+        warnings.warn(
+            (
+                'zip_equal will be removed in a future version of '
+                'more-itertools. Use the builtin zip function with '
+                'strict=True instead.'
+            ),
+            DeprecationWarning,
+        )
     # Check whether the iterables are all the same size.
     try:
         first_size = len(iterables[0])
@@ -1525,14 +1543,6 @@ def zip_equal(*iterables):
     # them until one runs out.
     except TypeError:
         return _zip_equal_generator(iterables)
-
-
-def _zip_equal_generator(iterables):
-    for combo in zip_longest(*iterables, fillvalue=_marker):
-        for val in combo:
-            if val is _marker:
-                raise UnequalIterablesError()
-        yield combo
 
 
 def zip_offset(*iterables, offsets, longest=False, fillvalue=None):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1490,7 +1490,6 @@ class UnequalIterablesError(ValueError):
         super().__init__(msg)
 
 
-
 def _zip_equal_generator(iterables):
     for combo in zip_longest(*iterables, fillvalue=_marker):
         for val in combo:
@@ -1517,7 +1516,7 @@ def zip_equal(*iterables):
         lengths
 
     """
-    if hexversion >= 0x30a00a6:
+    if hexversion >= 0x30A00A6:
         warnings.warn(
             (
                 'zip_equal will be removed in a future version of '

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1755,8 +1755,7 @@ class ZipEqualTest(TestCase):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter('always')
             self.assertEqual(
-                list(mi.zip_equal([1, 2], [3, 4])),
-                [(1, 3), (2, 4)]
+                list(mi.zip_equal([1, 2], [3, 4])), [(1, 3), (2, 4)]
             )
 
         (warning,) = caught

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,3 +1,5 @@
+import warnings
+
 from collections import Counter, abc
 from collections.abc import Set
 from datetime import datetime, timedelta
@@ -1748,7 +1750,17 @@ class StaggerTest(TestCase):
 
 
 class ZipEqualTest(TestCase):
-    """Tests for ``zip_equal()``"""
+    @skipIf(version_info[:2] < (3, 10), 'zip_equal deprecated for 3.10+')
+    def test_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            self.assertEqual(
+                list(mi.zip_equal([1, 2], [3, 4])),
+                [(1, 3), (2, 4)]
+            )
+
+        (warning,) = caught
+        assert warning.category == DeprecationWarning
 
     def test_equal(self):
         lists = [0, 1, 2], [2, 3, 4]


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/438, this PR adds a `DeprecationWarning` for `zip_equal` when running on Python 3.10 and higher.