### PR TITLE
Do not use an identity function when no key is given in the unique_everseen recipe

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -401,13 +401,14 @@ def unique_everseen(iterable, key=None):
     ``key=lambda x: frozenset(x.items())`` can be used.
 
     """
-    key = key if key is not None else lambda x: x
     seenset = set()
     seenset_add = seenset.add
     seenlist = []
     seenlist_add = seenlist.append
+    use_key = key is not None
+
     for element in iterable:
-        k = key(element)
+        k = key(element) if use_key else element
         try:
             if k not in seenset:
                 seenset_add(k)


### PR DESCRIPTION
The #488 PR simplified the function, but introduced an additional function call that occurred for every element, even when the `key` function was not supplied by the user.

### Changes
The call now occurs only if the `key` was supplied by the user.
```py
timeit tuple(unique_everseen_opt(range(10_000)))
1.04 ms ± 12.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

timeit tuple(unique_everseen_opt(range(1_000_000)))
138 ms ± 442 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)


timeit tuple(unique_everseen(range(10_000)))
1.52 ms ± 39.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

timeit tuple(unique_everseen(range(1_000_000)))
185 ms ± 4.95 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
(_opt is the new function)
the runtime difference here is not huge, but the complexity of the code hasn't increased much. The runtime when a `key` is supplied will also be a tiny bit bigger
