### PR TITLE
Add type overloads for zip_equal and zip_offset

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -24,6 +24,12 @@ from typing_extensions import ContextManager, Protocol, Type, overload
 
 # Type and type variable definitions
 _T = TypeVar('_T')
+_T1 = TypeVar('_T1')
+_T2 = TypeVar('_T2')
+_T3 = TypeVar('_T3')
+_T4 = TypeVar('_T4')
+_T5 = TypeVar('_T5')
+_T6 = TypeVar('_T6')
 _U = TypeVar('_U')
 _V = TypeVar('_V')
 _W = TypeVar('_W')
@@ -202,18 +208,140 @@ class UnequalIterablesError(ValueError):
         self, details: Optional[Tuple[int, int, int]] = ...
     ) -> None: ...
 
-def zip_equal(*iterables: Iterable[_T]) -> Iterator[Tuple[_T, ...]]: ...
+@overload
+def zip_equal(__iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
+@overload
+def zip_equal(__iter1: Iterable[_T1], __iter2: Iterable[_T2]) -> Iterator[Tuple[_T1, _T2]]: ...
+@overload
+def zip_equal(__iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3]) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
+@overload
+def zip_equal(
+    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], __iter4: Iterable[_T4]
+) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
+@overload
+def zip_equal(
+    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], __iter4: Iterable[_T4], __iter5: Iterable[_T5]
+) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
+@overload
+def zip_equal(
+    __iter1: Iterable[_T],
+    __iter2: Iterable[_T],
+    __iter3: Iterable[_T],
+    __iter4: Iterable[_T],
+    __iter5: Iterable[_T],
+    __iter6: Iterable[_T],
+    *iterables: Iterable[_T],
+) -> Iterator[Tuple[_T, ...]]: ...
+
 @overload
 def zip_offset(
-    *iterables: Iterable[_T], offsets: _SizedIterable[int], longest: bool = ...
+    __iter1: Iterable[_T1], *, offsets: _SizedIterable[int], longest: bool = ...
+) -> Iterator[Tuple[Optional[_T1]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1], __iter2: Iterable[_T2], *, offsets: _SizedIterable[int], longest: bool = ...
+) -> Iterator[Tuple[Optional[_T1], Optional[_T2]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], *, offsets: _SizedIterable[int], longest: bool = ...
+) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    __iter3: Iterable[_T3],
+    __iter4: Iterable[_T4],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...
+) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3], Optional[_T4]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    __iter3: Iterable[_T3],
+    __iter4: Iterable[_T4],
+    __iter5: Iterable[_T5],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...
+) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3], Optional[_T4], Optional[_T5]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T],
+    __iter2: Iterable[_T],
+    __iter3: Iterable[_T],
+    __iter4: Iterable[_T],
+    __iter5: Iterable[_T],
+    __iter6: Iterable[_T],
+    *iterables: Iterable[_T],
+    offsets: _SizedIterable[int],
+    longest: bool = ...
 ) -> Iterator[Tuple[Optional[_T], ...]]: ...
 @overload
 def zip_offset(
+    __iter1: Iterable[_T1],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...,
+    fillvalue: _U,
+) -> Iterator[Tuple[Union[_T1, _U]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...,
+    fillvalue: _U,
+) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    __iter3: Iterable[_T3],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...,
+    fillvalue: _U,
+) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    __iter3: Iterable[_T3],
+    __iter4: Iterable[_T4],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...,
+    fillvalue: _U,
+) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U], Union[_T4, _U]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    __iter3: Iterable[_T3],
+    __iter4: Iterable[_T4],
+    __iter5: Iterable[_T5],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...,
+    fillvalue: _U,
+) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U], Union[_T4, _U], Union[_T5, _U]]]: ...
+@overload
+def zip_offset(
+    __iter1: Iterable[_T],
+    __iter2: Iterable[_T],
+    __iter3: Iterable[_T],
+    __iter4: Iterable[_T],
+    __iter5: Iterable[_T],
+    __iter6: Iterable[_T],
     *iterables: Iterable[_T],
     offsets: _SizedIterable[int],
     longest: bool = ...,
-    fillvalue: _U
+    fillvalue: _U,
 ) -> Iterator[Tuple[Union[_T, _U], ...]]: ...
+
 def sort_together(
     iterables: Iterable[Iterable[_T]],
     key_list: Iterable[int] = ...,

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -222,7 +222,8 @@ def zip_offset(
     __iter1: Iterable[_T1],
     *,
     offsets: _SizedIterable[int],
-    longest: bool = ...
+    longest: bool = ...,
+    fillvalue: None = None
 ) -> Iterator[Tuple[Optional[_T1]]]: ...
 @overload
 def zip_offset(
@@ -230,7 +231,8 @@ def zip_offset(
     __iter2: Iterable[_T2],
     *,
     offsets: _SizedIterable[int],
-    longest: bool = ...
+    longest: bool = ...,
+    fillvalue: None = None
 ) -> Iterator[Tuple[Optional[_T1], Optional[_T2]]]: ...
 @overload
 def zip_offset(
@@ -239,7 +241,8 @@ def zip_offset(
     __iter3: Iterable[_T],
     *iterables: Iterable[_T],
     offsets: _SizedIterable[int],
-    longest: bool = ...
+    longest: bool = ...,
+    fillvalue: None = None
 ) -> Iterator[Tuple[Optional[_T], ...]]: ...
 @overload
 def zip_offset(

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -26,10 +26,6 @@ from typing_extensions import ContextManager, Protocol, Type, overload
 _T = TypeVar('_T')
 _T1 = TypeVar('_T1')
 _T2 = TypeVar('_T2')
-_T3 = TypeVar('_T3')
-_T4 = TypeVar('_T4')
-_T5 = TypeVar('_T5')
-_T6 = TypeVar('_T6')
 _U = TypeVar('_U')
 _V = TypeVar('_V')
 _W = TypeVar('_W')
@@ -213,25 +209,7 @@ def zip_equal(__iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
 @overload
 def zip_equal(__iter1: Iterable[_T1], __iter2: Iterable[_T2]) -> Iterator[Tuple[_T1, _T2]]: ...
 @overload
-def zip_equal(__iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3]) -> Iterator[Tuple[_T1, _T2, _T3]]: ...
-@overload
-def zip_equal(
-    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], __iter4: Iterable[_T4]
-) -> Iterator[Tuple[_T1, _T2, _T3, _T4]]: ...
-@overload
-def zip_equal(
-    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], __iter4: Iterable[_T4], __iter5: Iterable[_T5]
-) -> Iterator[Tuple[_T1, _T2, _T3, _T4, _T5]]: ...
-@overload
-def zip_equal(
-    __iter1: Iterable[_T],
-    __iter2: Iterable[_T],
-    __iter3: Iterable[_T],
-    __iter4: Iterable[_T],
-    __iter5: Iterable[_T],
-    __iter6: Iterable[_T],
-    *iterables: Iterable[_T],
-) -> Iterator[Tuple[_T, ...]]: ...
+def zip_equal(__iter1: Iterable[_T], __iter2: Iterable[_T], __iter3: Iterable[_T], *iterables: Iterable[_T]) -> Iterator[Tuple[_T, ...]]: ...
 
 @overload
 def zip_offset(
@@ -243,37 +221,9 @@ def zip_offset(
 ) -> Iterator[Tuple[Optional[_T1], Optional[_T2]]]: ...
 @overload
 def zip_offset(
-    __iter1: Iterable[_T1], __iter2: Iterable[_T2], __iter3: Iterable[_T3], *, offsets: _SizedIterable[int], longest: bool = ...
-) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3]]]: ...
-@overload
-def zip_offset(
-    __iter1: Iterable[_T1],
-    __iter2: Iterable[_T2],
-    __iter3: Iterable[_T3],
-    __iter4: Iterable[_T4],
-    *,
-    offsets: _SizedIterable[int],
-    longest: bool = ...
-) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3], Optional[_T4]]]: ...
-@overload
-def zip_offset(
-    __iter1: Iterable[_T1],
-    __iter2: Iterable[_T2],
-    __iter3: Iterable[_T3],
-    __iter4: Iterable[_T4],
-    __iter5: Iterable[_T5],
-    *,
-    offsets: _SizedIterable[int],
-    longest: bool = ...
-) -> Iterator[Tuple[Optional[_T1], Optional[_T2], Optional[_T3], Optional[_T4], Optional[_T5]]]: ...
-@overload
-def zip_offset(
     __iter1: Iterable[_T],
     __iter2: Iterable[_T],
     __iter3: Iterable[_T],
-    __iter4: Iterable[_T],
-    __iter5: Iterable[_T],
-    __iter6: Iterable[_T],
     *iterables: Iterable[_T],
     offsets: _SizedIterable[int],
     longest: bool = ...
@@ -297,45 +247,9 @@ def zip_offset(
 ) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U]]]: ...
 @overload
 def zip_offset(
-    __iter1: Iterable[_T1],
-    __iter2: Iterable[_T2],
-    __iter3: Iterable[_T3],
-    *,
-    offsets: _SizedIterable[int],
-    longest: bool = ...,
-    fillvalue: _U,
-) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U]]]: ...
-@overload
-def zip_offset(
-    __iter1: Iterable[_T1],
-    __iter2: Iterable[_T2],
-    __iter3: Iterable[_T3],
-    __iter4: Iterable[_T4],
-    *,
-    offsets: _SizedIterable[int],
-    longest: bool = ...,
-    fillvalue: _U,
-) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U], Union[_T4, _U]]]: ...
-@overload
-def zip_offset(
-    __iter1: Iterable[_T1],
-    __iter2: Iterable[_T2],
-    __iter3: Iterable[_T3],
-    __iter4: Iterable[_T4],
-    __iter5: Iterable[_T5],
-    *,
-    offsets: _SizedIterable[int],
-    longest: bool = ...,
-    fillvalue: _U,
-) -> Iterator[Tuple[Union[_T1, _U], Union[_T2, _U], Union[_T3, _U], Union[_T4, _U], Union[_T5, _U]]]: ...
-@overload
-def zip_offset(
     __iter1: Iterable[_T],
     __iter2: Iterable[_T],
     __iter3: Iterable[_T],
-    __iter4: Iterable[_T],
-    __iter5: Iterable[_T],
-    __iter6: Iterable[_T],
     *iterables: Iterable[_T],
     offsets: _SizedIterable[int],
     longest: bool = ...,

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -207,17 +207,30 @@ class UnequalIterablesError(ValueError):
 @overload
 def zip_equal(__iter1: Iterable[_T1]) -> Iterator[Tuple[_T1]]: ...
 @overload
-def zip_equal(__iter1: Iterable[_T1], __iter2: Iterable[_T2]) -> Iterator[Tuple[_T1, _T2]]: ...
+def zip_equal(
+    __iter1: Iterable[_T1], __iter2: Iterable[_T2]
+) -> Iterator[Tuple[_T1, _T2]]: ...
 @overload
-def zip_equal(__iter1: Iterable[_T], __iter2: Iterable[_T], __iter3: Iterable[_T], *iterables: Iterable[_T]) -> Iterator[Tuple[_T, ...]]: ...
-
+def zip_equal(
+    __iter1: Iterable[_T],
+    __iter2: Iterable[_T],
+    __iter3: Iterable[_T],
+    *iterables: Iterable[_T]
+) -> Iterator[Tuple[_T, ...]]: ...
 @overload
 def zip_offset(
-    __iter1: Iterable[_T1], *, offsets: _SizedIterable[int], longest: bool = ...
+    __iter1: Iterable[_T1],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...
 ) -> Iterator[Tuple[Optional[_T1]]]: ...
 @overload
 def zip_offset(
-    __iter1: Iterable[_T1], __iter2: Iterable[_T2], *, offsets: _SizedIterable[int], longest: bool = ...
+    __iter1: Iterable[_T1],
+    __iter2: Iterable[_T2],
+    *,
+    offsets: _SizedIterable[int],
+    longest: bool = ...
 ) -> Iterator[Tuple[Optional[_T1], Optional[_T2]]]: ...
 @overload
 def zip_offset(
@@ -255,7 +268,6 @@ def zip_offset(
     longest: bool = ...,
     fillvalue: _U,
 ) -> Iterator[Tuple[Union[_T, _U], ...]]: ...
-
 def sort_together(
     iterables: Iterable[Iterable[_T]],
     key_list: Iterable[int] = ...,


### PR DESCRIPTION
### Issue reference
Fixes #525 

### Changes
This adds overloaded type definitions for `zip_equal` and `zip_offset`, following the standard-library type definitions for `zip` ([2.x](https://github.com/python/typeshed/blob/master/stdlib/%40python2/builtins.pyi#L1030), [3.x](https://github.com/python/typeshed/blob/master/stdlib/builtins.pyi#L1310)). This creates special cases for 1-5 iterable arguments, and a fallback for 6 or more arguments or if called with varargs. This gives better type information in common situations when zipping a fixed number of iterables.
