### PR TITLE
Add transpose() function

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -106,6 +106,7 @@ __all__ = [
     'substrings',
     'substrings_indexes',
     'time_limited',
+    'transpose',
     'unique_to_each',
     'unzip',
     'windowed',
@@ -3791,6 +3792,33 @@ def permutation_index(element, iterable):
         del pool[r]
 
     return index
+
+
+def transpose(iter_of_iters, inner_type=None, fillvalue=None):
+    """Transpose an interable of iterables by switching the rows and columns.
+
+    Returns a generator that transpose an iterable of iterables. If the inner
+    iterable is of shorter length the missing values will be *fillvalue*.
+    If *inner_type* is defined the inner iterable will be made into its type.
+
+        >>> matrix = [[1, 2, 3], [4, 5, 6]]
+        >>> list(transpose(matrix))
+        [(1, 4), (2, 5), (3, 6)]
+        >>> list(transpose(matrix, inner_type=list))
+        [[1, 4], [2, 5], [3, 6]]
+        >>> jagged_matrix = [[1, 2], [3]]
+        >>> list(transpose(jagged_matrix))
+        [(1,3), (2, None)]
+        >>> database = (('Ahmed', 21), ('Sarah', 42))
+        >>> tuple(transpose(database))
+        (('Ahmed', 'Sarah'), (21, 42))
+
+    """
+    if inner_type:
+        return map(inner_type, zip_longest(*iter_of_iters,
+                                           fillvalue=fillvalue))
+    else:
+        return zip_longest(*iter_of_iters, fillvalue=fillvalue)
 
 
 class countable:

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -530,6 +530,10 @@ def combination_index(
 def permutation_index(
     element: Iterable[_T], iterable: Iterable[_T]
 ) -> int: ...
+def transpose(iter_of_iters: Iterable,
+              inner_type: Union[_T, None],
+              fillvalue: object
+              ) -> Iterator[Union[Iterable[_T], tuple]]: ...
 
 class countable(Generic[_T], Iterator[_T]):
     def __init__(self, iterable: Iterable[_T]) -> None: ...


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools #527

### Changes
Adds a new itertools function to transpose iterable of iterables. Useful for quite a few cases that is not necessarily numerical which wouldn't call for `numpy`.
