### PR TITLE
Changed repeat_each() implementation to accept infinite iterators as input

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1404,7 +1404,7 @@ def repeat_each(iterable, n=2):
     >>> list(repeat_each('ABC', 3))
     ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C']
     """
-    return chain(*map(repeat, iterable, repeat(n)))
+    return chain.from_iterable(map(repeat, iterable, repeat(n)))
 
 
 def repeat_last(iterable, default=None):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1693,17 +1693,7 @@ class RepeatEachTests(TestCase):
 
     def test_infinite_input(self):
         repeater = mi.repeat_each(cycle('AB'))
-        actual = []
-        counter = 0
-
-        while True:
-            current = next(repeater)
-            actual.append(current)
-            counter += 1
-
-            if counter == 6:
-                break
-
+        actual = mi.take(6, repeater)
         expected = ['A', 'A', 'B', 'B', 'A', 'A']
         self.assertEqual(actual, expected)
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -14,6 +14,7 @@ from itertools import (
     chain,
     combinations,
     count,
+    cycle,
     groupby,
     islice,
     permutations,
@@ -1688,6 +1689,22 @@ class RepeatEachTests(TestCase):
     def test_negative_repeat(self):
         actual = list(mi.repeat_each('ABC', -1))
         expected = []
+        self.assertEqual(actual, expected)
+
+    def test_infinite_input(self):
+        repeater = mi.repeat_each(cycle('AB'))
+        actual = []
+        counter = 0
+
+        while True:
+            current = next(repeater)
+            actual.append(current)
+            counter += 1
+
+            if counter == 6:
+                break
+
+        expected = ['A', 'A', 'B', 'B', 'A', 'A']
         self.assertEqual(actual, expected)
 
 


### PR DESCRIPTION
### Changes

As mentioned in #533 changed `repeat_each()` implementation to use `chain.from_iterable(map)` instead of `chain(*map)`. Since unpacking (`*map()`) consumes the whole iterator upfront it doesn't work for infinite iterators. Using `chain.from_iterable()` on the other hand consumes the passed iterator lazily, resulting in (1) the possibility of infinite iterators as input as well as (2) less memory usage for large inputs since the map iterator doesn't need to be loaded into memory before being passed to `chain`.

Also mentioned here:
https://stackoverflow.com/questions/39533052/difference-between-chainiterable-vs-chain-from-iterableiterable