### PR TITLE
Remove include_package_data option from setup.py to fix type stubs not included in sdist.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     license='MIT',
     packages=['more_itertools'],
     package_data={'more_itertools': ['py.typed', '*.pyi']},
-    include_package_data=True,
     python_requires='>=3.5',
     url='https://github.com/more-itertools/more-itertools',
     classifiers=[


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#553

### Changes
Remove include_package_data option from setup.py
The package_data option will be used for both sdist and bdist with this change.
