### PR TITLE
Fix `groupby_transform` type hints

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -303,34 +303,49 @@ def adjacent(
 @overload
 def groupby_transform(
     iterable: Iterable[_T],
+    keyfunc: None = None,
+    valuefunc: None = None,
+    reducefunc: None = None,
 ) -> Iterator[Tuple[_T, Iterator[_T]]]: ...
 @overload
 def groupby_transform(
-    iterable: Iterable[_T], keyfunc: Callable[[_T], _U]
+    iterable: Iterable[_T],
+    keyfunc: Callable[[_T], _U],
+    valuefunc: None,
+    reducefunc: None,
 ) -> Iterator[Tuple[_U, Iterator[_T]]]: ...
 @overload
 def groupby_transform(
-    iterable: Iterable[_T], valuefunc: Callable[[_T], _V]
+    iterable: Iterable[_T],
+    keyfunc: None,
+    valuefunc: Callable[[_T], _V],
+    reducefunc: None,
 ) -> Iterable[Tuple[_T, Iterable[_V]]]: ...
 @overload
 def groupby_transform(
     iterable: Iterable[_T],
     keyfunc: Callable[[_T], _U],
     valuefunc: Callable[[_T], _V],
+    reducefunc: None,
 ) -> Iterable[Tuple[_U, Iterator[_V]]]: ...
 @overload
 def groupby_transform(
-    iterable: Iterable[_T], reducefunc: Callable[[Iterator[_T]], _W]
+    iterable: Iterable[_T],
+    keyfunc: None,
+    valuefunc: None,
+    reducefunc: Callable[[Iterator[_T]], _W],
 ) -> Iterable[Tuple[_T, _W]]: ...
 @overload
 def groupby_transform(
     iterable: Iterable[_T],
     keyfunc: Callable[[_T], _U],
+    valuefunc: None,
     reducefunc: Callable[[Iterator[_T]], _W],
 ) -> Iterable[Tuple[_U, _W]]: ...
 @overload
 def groupby_transform(
     iterable: Iterable[_T],
+    keyfunc: None,
     valuefunc: Callable[[_T], _V],
     reducefunc: Callable[[Iterable[_V]], _W],
 ) -> Iterable[Tuple[_T, _W]]: ...


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#567

### Changes
I fixed type-hints for the `groupby_transform` by splitting its stubs into overloads matching all possible call signatures.

The fix required writing 8 overloads, one for each possible combination of optional parameters. I tried to simplify those overloads by annotating e.g. `keyfunc: Callable[[_T], _U] = identity`, where `identity: Callable[[_Z] _Z]` is the identity function. However, this failed as per https://github.com/python/mypy/issues/3737.

Fixes #567.
