### PR TITLE
Add docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,29 @@
+# What we want
+Sphinx==4.2.0
+sphinx-rtd-theme==1.0.0
+
+# What we get
+alabaster==0.7.12
+appdirs==1.4.4
+Babel==2.9.1
+certifi==2021.10.8
+charset-normalizer==2.0.7
+docutils==0.17.1
+idna==3.3
+imagesize==1.3.0
+Jinja2==3.0.3
+MarkupSafe==2.0.1
+packaging==20.3
+Pygments==2.10.0
+pyparsing==2.4.7
+pytz==2021.3
+requests==2.26.0
+six==1.14.0
+snowballstemmer==2.1.0
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+urllib3==1.26.7


### PR DESCRIPTION
Re: https://github.com/readthedocs/readthedocs.org/issues/8616#issuecomment-952034858, this PR adds a `requirements.txt` file for ReadTheDocs. This will fix the broken RTD build (I hope).