### PR TITLE
Update setup.py to require Python 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     license='MIT',
     packages=['more_itertools'],
     package_data={'more_itertools': ['py.typed', '*.pyi']},
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     url='https://github.com/more-itertools/more-itertools',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION


### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#578

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
Bumps `python_requires` to '>=3.6'
