### PR TITLE
Fix inefficient use of `tee`s in `ichunked

### DIFF
--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -29,6 +29,7 @@ from string import ascii_letters
 from sys import version_info, getsizeof
 from time import sleep
 from traceback import format_exc
+import tracemalloc
 from unittest import skipIf, TestCase
 
 import more_itertools as mi
@@ -4042,15 +4043,16 @@ class IchunkedTests(TestCase):
         iterated over in order."""
         def big_string_iterator():
             while True:
-                yield 'X'*5000 # Must be larger than 4096 to get around interning
+                # Must be larger than 4096 to get around str interning
+                yield 'X' * 5000
 
-        import tracemalloc
         ichunks = mi.ichunked(big_string_iterator(), 50)
         ichunk = next(ichunks)
         tracemalloc.start()
         mi.consume(ichunk)
         curr_mem, peak_mem = tracemalloc.get_traced_memory()
-        self.assertLess(peak_mem, getsizeof('X'*5000)*2)
+        tracemalloc.stop()
+        self.assertLess(peak_mem, getsizeof('X' * 5000) * 2)
 
 
 class DistinctCombinationsTests(TestCase):


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#586

### Changes
ichunked makes tees for every chunk, which lets us iterate on chunks out of order, but also always creates a cache within the chunk, even if we iterate through all the chunks in order.

Example:
```python
def big_string_generator():
    while True:
        yield 'X'*5000
ichunk = next(ichunked(big_string_generator(), 1000))
consume(ichunk) # You'll see a very large memory spike here
```

I've fixed by creating an auxiliary `_IChunk` class which holds a cache that we only manually fill after a new chunk is requested. If the previous chunk has been consumed by the time a new chunk is requested, then the cache will get filled with nothing (saving us memory)