### PR TITLE
replace `starmap`+`zip` combination with `map`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2684,7 +2684,7 @@ def difference(iterable, func=sub, *, initial=None):
     if initial is not None:
         first = []
 
-    return chain(first, starmap(func, zip(b, a)))
+    return chain(first, map(func, b, a))
 
 
 class SequenceView(Sequence):


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
No issues related

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
Replace `starmap` + `zip` with simple `map`. No new failed tests (one test is fail before and after changes).

I also discovered this speeds up a little bit:
![image](https://user-images.githubusercontent.com/47028153/151735413-9a971a49-181b-4a38-98c7-407ed75b1863.png)

