### PR TITLE
Add grouper's incomplete mode

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -20,6 +20,7 @@ from itertools import (
     islice,
     repeat,
     starmap,
+    takewhile,
     tee,
     zip_longest,
 )
@@ -347,6 +348,11 @@ def grouper(iterable, n, incomplete='fill', fillvalue=None):
     >>> list(grouper('ABCDEFG', 3, incomplete='ignore', fillvalue='x'))
     [('A', 'B', 'C'), ('D', 'E', 'F')]
 
+    When *incomplete* is `'allow'`, the last group will be emitted as incompleted.
+
+    >>> list(map(tuple, grouper('ABCDEFG', 3, incomplete='allow')))
+    [('A', 'B', 'C'), ('D', 'E', 'F'), ('G',)]
+
     When *incomplete* is `'strict'`, a subclass of `ValueError` will be raised.
 
     >>> it = grouper('ABCDEFG', 3, incomplete='strict')
@@ -368,6 +374,11 @@ def grouper(iterable, n, incomplete='fill', fillvalue=None):
         return _zip_equal(*args)
     if incomplete == 'ignore':
         return zip(*args)
+    if incomplete == 'allow':
+        return (
+            takewhile(lambda x: x is not _marker, group)
+            for group in zip_longest(*args, fillvalue=_marker)
+        )
     else:
         raise ValueError('Expected fill, strict, or ignore')
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -307,6 +307,22 @@ class GrouperTests(TestCase):
                 actual = [''.join(x) for x in it]
                 self.assertEqual(actual, expected)
 
+    def test_allow(self):
+        seq = 'ABCDEF'
+        for n, expected in [
+            (1, ['A', 'B', 'C', 'D', 'E', 'F']),
+            (2, ['AB', 'CD', 'EF']),
+            (3, ['ABC', 'DEF']),
+            (4, ['ABCD', 'EF']),
+            (5, ['ABCDE', 'F']),
+            (6, ['ABCDEF']),
+            (7, ['ABCDEF']),
+        ]:
+            with self.subTest(n=n):
+                it = mi.grouper(iter(seq), n, incomplete='allow')
+                actual = [''.join(x) for x in it]
+                self.assertEqual(actual, expected)
+
     def test_strict(self):
         seq = 'ABCDEF'
         for n, expected in [


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#619

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
- Add an option of `grouper` function, named `'allow'`
- Add testcase for `'allow'` mode