### PR TITLE
Lazily import ThreadPoolExecutor

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3636,6 +3636,7 @@ class callback_iter:
         self._aborted = False
         self._future = None
         self._wait_seconds = wait_seconds
+        # Lazily import concurrent.future
         self._executor = __import__(
             'concurrent.futures'
         ).futures.ThreadPoolExecutor(max_workers=1)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2,7 +2,6 @@ import warnings
 
 from collections import Counter, defaultdict, deque, abc
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial, reduce, wraps
 from heapq import merge, heapify, heapreplace, heappop
 from itertools import (
@@ -3637,7 +3636,9 @@ class callback_iter:
         self._aborted = False
         self._future = None
         self._wait_seconds = wait_seconds
-        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._executor = __import__('concurrent').futures.ThreadPoolExecutor(
+            max_workers=1
+        )
         self._iterator = self._reader()
 
     def __enter__(self):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3636,9 +3636,9 @@ class callback_iter:
         self._aborted = False
         self._future = None
         self._wait_seconds = wait_seconds
-        self._executor = __import__('concurrent').futures.ThreadPoolExecutor(
-            max_workers=1
-        )
+        self._executor = __import__(
+            'concurrent.futures'
+        ).futures.ThreadPoolExecutor(max_workers=1)
         self._iterator = self._reader()
 
     def __enter__(self):


### PR DESCRIPTION
Re: https://github.com/pypa/setuptools/pull/3091 - I'm late in noticing this, but had I seen this issue in `setuptools` before I would have made this upstream change.

I'll ping @jaraco for comment. Feel free to request changes like this if something in `more_itertools` interferes with smooth operation of `setuptools`. I think it's awesome (and a little terrifying) to have this project included in such a critical package, and as long as that's the case want to make things work well.