### PR TITLE
docs: fix simple typo, versiosn -> versions

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3942,7 +3942,7 @@ def combination_index(element, iterable):
 
     n, _ = last(pool, default=(n, None))
 
-    # Python versiosn below 3.8 don't have math.comb
+    # Python versions below 3.8 don't have math.comb
     index = 1
     for i, j in enumerate(reversed(indexes), start=1):
         j = n - j


### PR DESCRIPTION
There is a small typo in more_itertools/more.py.

Should read `versions` rather than `versiosn`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md