### PR TITLE
Add function `longest_common_prefix`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -190,6 +190,7 @@ These tools yield certain items from an iterable.
 .. autofunction:: unique_in_window
 .. autofunction:: duplicates_everseen
 .. autofunction:: duplicates_justseen
+.. autofunction:: longest_common_prefix
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2341,8 +2341,8 @@ def locate(iterable, pred=bool, window_size=None):
 def longest_common_prefix(iterables):
     """Yield elements of the longest common prefix amongst given *iterables*.
 
-        >>> ''.join(longest_common_prefix(['abcd', 'abc', 'abf']))
-        'ab'
+    >>> ''.join(longest_common_prefix(['abcd', 'abc', 'abf']))
+    'ab'
 
     """
     return (c[0] for c in takewhile(all_equal, zip(*iterables)))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -35,6 +35,7 @@ from .recipes import (
     powerset,
     take,
     unique_everseen,
+    all_equal,
 )
 
 __all__ = [
@@ -79,6 +80,7 @@ __all__ = [
     'iterate',
     'last',
     'locate',
+    'longest_common_prefix',
     'lstrip',
     'make_decorator',
     'map_except',
@@ -2334,6 +2336,16 @@ def locate(iterable, pred=bool, window_size=None):
 
     it = windowed(iterable, window_size, fillvalue=_marker)
     return compress(count(), starmap(pred, it))
+
+
+def longest_common_prefix(iterables):
+    """Yield elements of the longest common prefix amongst given *iterables*.
+
+        >>> ''.join(longest_common_prefix(['abcd', 'abc', 'abf']))
+        'ab'
+
+    """
+    return (c[0] for c in takewhile(all_equal, zip(*iterables)))
 
 
 def lstrip(iterable, pred):

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -662,3 +662,7 @@ def minmax(
     *others: _T,
     key: Callable[[_T], _SupportsLessThan]
 ) -> Tuple[_T, _T]: ...
+
+def longest_common_prefix(
+    iterables: Iterable[Iterable[_T]]
+) -> Iterator[_T]: ...

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -662,7 +662,6 @@ def minmax(
     *others: _T,
     key: Callable[[_T], _SupportsLessThan]
 ) -> Tuple[_T, _T]: ...
-
 def longest_common_prefix(
-    iterables: Iterable[Iterable[_T]]
+    iterables: Iterable[Iterable[_T]],
 ) -> Iterator[_T]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5054,3 +5054,50 @@ class DuplicatesJustSeenTests(TestCase):
     def test_nested(self):
         iterable = [[[1, 2], [1, 2]], [5, 6], [5, 6]]
         self.assertEqual(list(mi.duplicates_justseen(iterable)), [[5, 6]])
+
+
+class LongestCommonPrefixTests(TestCase):
+    def test_basic(self):
+        iterables = [[1, 2], [1, 2, 3], [1, 2, 4]]
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [1, 2])
+
+    def test_iterators(self):
+        iterables = iter([iter([1, 2]), iter([1, 2, 3]), iter([1, 2, 4])])
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [1, 2])
+
+    def test_no_iterables(self):
+        iterables = []
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [])
+
+    def test_empty_iterables_only(self):
+        iterables = [[], [], []]
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [])
+
+    def test_includes_empty_iterables(self):
+        iterables = [[1, 2], [1, 2, 3], [1, 2, 4], []]
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [])
+
+    def test_non_hashable(self):
+        # See https://github.com/more-itertools/more-itertools/issues/603
+        iterables = [[[1], [2]], [[1], [2], [3]], [[1], [2], [4]]]
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [[1], [2]])
+
+    def test_prefix_contains_elements_of_the_first_iterable(self):
+        iterables = [[[1], [2]], [[1], [2], [3]], [[1], [2], [4]]]
+        prefix = list(mi.longest_common_prefix(iterables))
+        self.assertIs(prefix[0], iterables[0][0])
+        self.assertIs(prefix[1], iterables[0][1])
+        self.assertIsNot(prefix[0], iterables[1][0])
+        self.assertIsNot(prefix[1], iterables[1][1])
+        self.assertIsNot(prefix[0], iterables[2][0])
+        self.assertIsNot(prefix[1], iterables[2][1])
+
+    def test_infinite_iterables(self):
+        prefix = mi.longest_common_prefix([count(), count()])
+        self.assertEqual(next(prefix), 0)
+        self.assertEqual(next(prefix), 1)
+        self.assertEqual(next(prefix), 2)
+
+    def test_contains_infinite_iterables(self):
+        iterables = [[0, 1, 2], count()]
+        self.assertEqual(list(mi.longest_common_prefix(iterables)), [0, 1, 2])


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#603

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
Added a `longest_common_prefix` function based on the discussion in the linked issue. This implementation includes a new test case and type annotations.

The new function accepts an iterable of iterables, because it seems more useful in typical cases.

```python
>>> links = [
...    'https://stackoverflow.com/questions/60842684/longest-common-prefix-with-python',
...    'https://stackoverflow.com/questions/64628158/find-the-longest-common-prefix-string-amongst-a-list-of-strings'
... ]
... ''.join(longest_common_prefix(links))
'https://stackoverflow.com/questions/6'
```