### PR TITLE
Optimize memory allocation for `tail` function

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -107,6 +107,10 @@ def tail(n, iterable):
     ['E', 'F', 'G']
 
     """
+    # If the given iterable has a length, then we can use islice to get its
+    # final elements. Note that if the iterable is not actually Iterable,
+    # either islice or deque will throw a TypeError. This is why we don't
+    # check if it is Iterable.
     if isinstance(iterable, Sized):
         yield from islice(iterable, max(0, len(iterable) - n), None)
     else:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -11,7 +11,7 @@ import operator
 import warnings
 
 from collections import deque
-from collections.abc import Sized
+from collections.abc import Collection
 from itertools import (
     chain,
     combinations,
@@ -107,7 +107,7 @@ def tail(n, iterable):
     ['E', 'F', 'G']
 
     """
-    if isinstance(iterable, Sized):
+    if isinstance(iterable, Collection):
         yield from islice(iterable, max(0, len(iterable) - n), None)
     else:
         yield from iter(deque(iterable, maxlen=n))

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -11,7 +11,7 @@ import operator
 import warnings
 
 from collections import deque
-from collections.abc import Collection
+from collections.abc import Sized
 from itertools import (
     chain,
     combinations,
@@ -107,7 +107,7 @@ def tail(n, iterable):
     ['E', 'F', 'G']
 
     """
-    if isinstance(iterable, Collection):
+    if isinstance(iterable, Sized):
         yield from islice(iterable, max(0, len(iterable) - n), None)
     else:
         yield from iter(deque(iterable, maxlen=n))

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -11,6 +11,7 @@ import operator
 import warnings
 
 from collections import deque
+from collections.abc import Sized
 from itertools import (
     chain,
     combinations,
@@ -106,7 +107,10 @@ def tail(n, iterable):
     ['E', 'F', 'G']
 
     """
-    return iter(deque(iterable, maxlen=n))
+    if isinstance(iterable, Sized):
+        yield from islice(iterable, max(0, len(iterable) - n), None)
+    else:
+        yield from iter(deque(iterable, maxlen=n))
 
 
 def consume(iterator, n=None):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -77,7 +77,6 @@ class TailTests(TestCase):
 
     def test_sized_equal(self):
         """Length of sized iterable is less than requested tail"""
-        tail = list(mi.tail(7, 'ABCDEFG'))
         self.assertEqual(list(mi.tail(7, 'ABCDEFG')), list('ABCDEFG'))
 
     def test_sized_less(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -59,21 +59,30 @@ class TabulateTests(TestCase):
 class TailTests(TestCase):
     """Tests for ``tail()``"""
 
-    def test_greater(self):
-        """Length of iterable is greater than requested tail"""
-        self.assertEqual(list(mi.tail(3, 'ABCDEFG')), ['E', 'F', 'G'])
+    def test_iterator_greater(self):
+        """Length of iterator is greater than requested tail"""
+        self.assertEqual(list(mi.tail(3, iter('ABCDEFG'))), list('EFG'))
 
-    def test_equal(self):
-        """Length of iterable is equal to the requested tail"""
-        self.assertEqual(
-            list(mi.tail(7, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
-        )
+    def test_iterator_equal(self):
+        """Length of iterator is equal to the requested tail"""
+        self.assertEqual(list(mi.tail(7, iter('ABCDEFG'))), list('ABCDEFG'))
 
-    def test_less(self):
-        """Length of iterable is less than requested tail"""
-        self.assertEqual(
-            list(mi.tail(8, 'ABCDEFG')), ['A', 'B', 'C', 'D', 'E', 'F', 'G']
-        )
+    def test_iterator_less(self):
+        """Length of iterator is less than requested tail"""
+        self.assertEqual(list(mi.tail(8, iter('ABCDEFG'))), list('ABCDEFG'))
+
+    def test_sized_greater(self):
+        """Length of sized iterable is greater than requested tail"""
+        self.assertEqual(list(mi.tail(3, 'ABCDEFG')), list('EFG'))
+
+    def test_sized_equal(self):
+        """Length of sized iterable is less than requested tail"""
+        tail = list(mi.tail(7, 'ABCDEFG'))
+        self.assertEqual(list(mi.tail(7, 'ABCDEFG')), list('ABCDEFG'))
+
+    def test_sized_less(self):
+        """Length of sized iterable is less than requested tail"""
+        self.assertEqual(list(mi.tail(8, 'ABCDEFG')), list('ABCDEFG'))
 
 
 class ConsumeTests(TestCase):


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#510

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
The `tail` function no longer allocates memory for elements if we never request elements from the tail. If it is possible to determine the size of an iterable without iterating over its elements, we will no longer load all the elements of the tail into memory.