### PR TITLE
Small fix of `islice_extended` test

### DIFF
--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3218,7 +3218,7 @@ class StripFunctionTests(TestCase):
 class IsliceExtendedTests(TestCase):
     def test_all(self):
         iterable = ['0', '1', '2', '3', '4', '5']
-        indexes = [-10, -6, -5, -4, -2, -1, 0, 1, 2, 4, 5, 6, 10, None]
+        indexes = [*range(-4, 10), None]
         steps = [1, 2, 3, 4, -1, -2, -3, -4]
         for slice_args in product(indexes, indexes, steps):
             with self.subTest(slice_args=slice_args):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3218,8 +3218,8 @@ class StripFunctionTests(TestCase):
 class IsliceExtendedTests(TestCase):
     def test_all(self):
         iterable = ['0', '1', '2', '3', '4', '5']
-        indexes = list(range(-4, len(iterable) + 4)) + [None]
-        steps = [1, 2, 3, 4, -1, -2, -3, 4]
+        indexes = [-10, -6, -5, -4, -2, -1, 0, 1, 2, 4, 5, 6, 10, None]
+        steps = [1, 2, 3, 4, -1, -2, -3, -4]
         for slice_args in product(indexes, indexes, steps):
             with self.subTest(slice_args=slice_args):
                 actual = list(mi.islice_extended(iterable, *slice_args))


### PR DESCRIPTION
### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
Previously, the test checked the same `step` 4 twice, although the author obviously meant -4. I fixed it. Also, all `start` and `stop` values from -4 to 9 were checked, although it is enough to check the usual values, values at the borders, and values beyond the borders. I changed that too and this test was performed twice as fast. It ain't much but it's honest work.