### PR TITLE
Python 3.10 trove

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
I noticed that CI runs against 3.10, but that there's no trove available in PyPi. Given that we wanted to use this library, and poetry dies, I thought this PR prudent.

For reference, we will use it here: https://github.com/redis/redis-om-python/pull/305