### PR TITLE
Optimize `islice_extended` for `Sized` iterables

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2437,11 +2437,10 @@ class islice_extended:
     """
 
     def __init__(self, iterable, *args):
-        it = iter(iterable)
         if args:
-            self._iterable = _islice_helper(it, slice(*args))
+            self._iterable = _islice_helper(iterable, slice(*args))
         else:
-            self._iterable = it
+            self._iterable = iter(iterable)
 
     def __iter__(self):
         return self
@@ -2456,30 +2455,31 @@ class islice_extended:
         raise TypeError('islice_extended.__getitem__ argument must be a slice')
 
 
-def _islice_helper(it, s):
-    start = s.start
-    stop = s.stop
-    if s.step == 0:
+def _islice_helper(iterable, s):
+    start, stop, step = s.start, s.stop, s.step
+    if step == 0:
         raise ValueError('step argument must be a non-zero integer or None.')
-    step = s.step or 1
+    step = step or 1
 
     if step > 0:
-        start = 0 if (start is None) else start
+        start = 0 if start is None else start
 
         if start >= 0 and (stop is None or stop >= 0):
             # When both start and stop are positive we have the normal case
-            yield from islice(it, start, stop, step)
-        elif isinstance(it, Sized):
+            yield from islice(iterable, start, stop, step)
+        elif isinstance(iterable, Sized):
             # If start or stop is negative, but the length is known, we
             # can adjust start and stop to be positive and reduce this case
             # to the previous one.
-            length = len(it)
-            start = start if start >= 0 else max(0, length + start)
-            stop = stop if stop >= 0 else max(0, length + stop)
-            yield from islice(it, start, stop, step)
+            length = len(iterable)
+            if start < 0:
+                start = max(0, length + start)
+            if stop is not None and stop < 0:
+                stop = max(0, length + stop)
+            yield from islice(iterable, start, stop, step)
         elif start < 0:
             # Consume all but the last -start items
-            cache = deque(enumerate(it, 1), maxlen=-start)
+            cache = deque(enumerate(iterable, 1), maxlen=-start)
             len_iter = cache[-1][0] if cache else 0
 
             # Adjust start to be positive
@@ -2501,25 +2501,45 @@ def _islice_helper(it, s):
             for index, item in islice(cache, 0, n, step):
                 yield item
         else:
+            iterator = iter(iterable)
             # Advance to the start position
-            next(islice(it, start, start), None)
+            next(islice(iterator, start, start), None)
 
             # When stop is negative, we have to carry -stop items while
             # iterating
-            cache = deque(islice(it, -stop), maxlen=-stop)
+            cache = deque(islice(iterator, -stop), maxlen=-stop)
 
-            for index, item in enumerate(it):
+            for index, item in enumerate(iterator):
                 cached_item = cache.popleft()
                 if index % step == 0:
                     yield cached_item
                 cache.append(item)
     else:
-        start = -1 if (start is None) else start
+        start = -1 if start is None else start
 
-        if (stop is not None) and (stop < 0):
+        if start >= 0 and (stop is None or stop >= 0):
+            # When both start and stop are positive, we can just use islice.
+            stop = -1 if stop is None else stop
+            yield from list(islice(iterable, stop + 1, start + 1))[::step]
+        elif isinstance(iterable, Sized):
+            # If start or stop is negative, but the length of iterable is
+            # known, we can adjust start and stop and use islice again.
+            length = len(iterable)
+            if stop is None:
+                i = 0
+            elif stop >= 0:
+                i = stop + 1
+            else:
+                i = max(0, length + stop + 1)
+            if start >= 0:
+                j = start + 1
+            else:
+                j = max(0, length + start + 1)
+            yield from list(islice(iterable, i, j))[::step]
+        elif stop is not None and stop < 0:
             # Consume all but the last items
             n = -stop - 1
-            cache = deque(enumerate(it, 1), maxlen=n)
+            cache = deque(enumerate(iterable, 1), maxlen=n)
             len_iter = cache[-1][0] if cache else 0
 
             # If start and stop are both negative they are comparable and
@@ -2533,10 +2553,11 @@ def _islice_helper(it, s):
             for index, item in list(cache)[i:j:step]:
                 yield item
         else:
+            iterator = iter(iterable)
             # Advance to the stop position
             if stop is not None:
                 m = stop + 1
-                next(islice(it, m, m), None)
+                next(islice(iterator, m, m), None)
 
             # stop is positive, so if start is negative they are not comparable
             # and we need the rest of the items.
@@ -2555,7 +2576,7 @@ def _islice_helper(it, s):
                 if n <= 0:
                     return
 
-            cache = list(islice(it, n))
+            cache = list(islice(iterator, n))
 
             yield from cache[i::step]
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3218,7 +3218,7 @@ class StripFunctionTests(TestCase):
 class IsliceExtendedTests(TestCase):
     def test_all_sequence(self):
         iterable = ['0', '1', '2', '3', '4', '5']
-        indexes = [*range(-4, 10), None]
+        indexes = [*range(-10, 10), None]
         steps = [1, 2, 3, 4, -1, -2, -3, -4]
         for slice_args in product(indexes, indexes, steps):
             with self.subTest(slice_args=slice_args):
@@ -3228,7 +3228,7 @@ class IsliceExtendedTests(TestCase):
 
     def test_all_iterator(self):
         iterable = ['0', '1', '2', '3', '4', '5']
-        indexes = [*range(-4, 10), None]
+        indexes = [*range(-10, 10), None]
         steps = [1, 2, 3, 4, -1, -2, -3, -4]
         for slice_args in product(indexes, indexes, steps):
             with self.subTest(slice_args=slice_args):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3216,13 +3216,23 @@ class StripFunctionTests(TestCase):
 
 
 class IsliceExtendedTests(TestCase):
-    def test_all(self):
+    def test_all_sequence(self):
         iterable = ['0', '1', '2', '3', '4', '5']
         indexes = [*range(-4, 10), None]
         steps = [1, 2, 3, 4, -1, -2, -3, -4]
         for slice_args in product(indexes, indexes, steps):
             with self.subTest(slice_args=slice_args):
                 actual = list(mi.islice_extended(iterable, *slice_args))
+                expected = iterable[slice(*slice_args)]
+                self.assertEqual(actual, expected, slice_args)
+
+    def test_all_iterator(self):
+        iterable = ['0', '1', '2', '3', '4', '5']
+        indexes = [*range(-4, 10), None]
+        steps = [1, 2, 3, 4, -1, -2, -3, -4]
+        for slice_args in product(indexes, indexes, steps):
+            with self.subTest(slice_args=slice_args):
+                actual = list(mi.islice_extended(iter(iterable), *slice_args))
                 expected = iterable[slice(*slice_args)]
                 self.assertEqual(actual, expected, slice_args)
 


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#635

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
The `islice_extended` with positive `step` no longer allocates memory for elements if `start` or `stop` is negative, but the iterable is `Sized`. I raised the usual case check to the top, because an attempt to apply optimization should occur before the non-optimized processing of negative start/stop is applied, but I would like the `isinstance` check not to be performed if the case is normal.