### PR TITLE
Add function `batched`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: ichunked
 .. autofunction:: chunked_even
 .. autofunction:: sliced
+.. autofunction:: batched(iterable, size, get_size=len, strict=True)
 .. autofunction:: distribute
 .. autofunction:: divide
 .. autofunction:: split_at

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,7 +17,7 @@ These tools yield groups of items from a source iterable.
 .. autofunction:: ichunked
 .. autofunction:: chunked_even
 .. autofunction:: sliced
-.. autofunction:: batched(iterable, size, get_size=len, strict=True)
+.. autofunction:: batched(iterable, max_size, max_count=None, get_len=len, strict=True)
 .. autofunction:: distribute
 .. autofunction:: divide
 .. autofunction:: split_at

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4334,37 +4334,49 @@ def minmax(iterable_or_value, *others, key=None, default=_marker):
     return lo, hi
 
 
-def batched(iterable, size, get_len=len, strict=True):
+def batched(iterable, max_size, max_count=None, get_len=len, strict=True):
     """Yield batches of items from *iterable* with a combined size limited by
-    *size*.
+    *max_size*.
 
     >>> iterable = [b'12345', b'123', b'12345678', b'1', b'1', b'12', b'1']
     >>> list(batched(iterable, 10))
     [(b'12345', b'123'), (b'12345678', b'1', b'1'), (b'12', b'1')]
 
+    If a *max_count* is supplied, the number of items per batch is also
+    limited:
+
+    >>> iterable = [b'12345', b'123', b'12345678', b'1', b'1', b'12', b'1']
+    >>> list(batched(iterable, 10, max_count = 2))
+    [(b'12345', b'123'), (b'12345678', b'1'), (b'1', b'12'), (b'1',)]
+
     If a *get_len* function is supplied, use that instead of :func:`len` to
     determine item size.
 
     If *strict* is ``True``, raise ``ValueError`` if any single item is bigger
-    than *size*. Otherwise, allow single items to exceed *size*.
+    than *max_size*. Otherwise, allow single items to exceed *max_size*.
     """
-    if size <= 0:
+    if max_size <= 0:
         raise ValueError('maximum size must be greater than zero')
 
     batch = []
     batch_size = 0
+    batch_count = 0
     for item in iterable:
         item_len = get_len(item)
-        if strict and item_len > size:
+        if strict and item_len > max_size:
             raise ValueError('item size exceeds maximum size')
 
-        if batch_size and item_len + batch_size > size:
+        reached_count = batch_count == max_count
+        reached_size = item_len + batch_size > max_size
+        if batch_count and (reached_size or reached_count):
             yield tuple(batch)
             batch.clear()
             batch_size = 0
+            batch_count = 0
 
         batch.append(item)
         batch_size += item_len
+        batch_count += 1
 
     if batch:
         yield tuple(batch)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4354,16 +4354,17 @@ def batched(iterable, size, get_len=len, strict=True):
     batch = []
     batch_size = 0
     for item in iterable:
-        if strict and get_len(item) > size:
+        item_len = get_len(item)
+        if strict and item_len > size:
             raise ValueError('item size exceeds maximum size')
 
-        if batch_size and get_len(item) + batch_size > size:
+        if batch_size and item_len + batch_size > size:
             yield tuple(batch)
             batch.clear()
             batch_size = 0
 
         batch.append(item)
-        batch_size += get_len(item)
+        batch_size += item_len
 
     if batch:
         yield tuple(batch)

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -668,7 +668,8 @@ def longest_common_prefix(
 def iequals(*iterables: Iterable[object]) -> bool: ...
 def batched(
     iterable: Iterable[object],
-    size: int,
+    max_size: int,
+    max_count: Optional[int] = ...,
     get_len: Callable[[_T], object] = ...,
     strict: bool = ...,
 ) -> Iterator[Tuple[_T]]: ...

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -666,3 +666,9 @@ def longest_common_prefix(
     iterables: Iterable[Iterable[_T]],
 ) -> Iterator[_T]: ...
 def iequals(*iterables: Iterable[object]) -> bool: ...
+def batched(
+    iterable: Iterable[object],
+    size: int,
+    get_len: Callable[[_T], object] = ...,
+    strict: bool = ...,
+) -> Iterator[Tuple[_T]]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5197,6 +5197,14 @@ class BatchedTests(TestCase):
                 actual = list(mi.batched(iter(zen), size))
                 self.assertEqual(actual, expected)
 
+    def test_max_count(self):
+        iterable = ['1', '1', '12345678', '12345', '12345']
+        max_size = 10
+        max_count = 2
+        actual = list(mi.batched(iterable, max_size, max_count))
+        expected = [('1', '1'), ('12345678',), ('12345', '12345')]
+        self.assertEqual(actual, expected)
+
     def test_strict(self):
         iterable = ['1', '123456789', '1']
         size = 8

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5137,3 +5137,88 @@ class IequalsTests(TestCase):
 
     def test_not_identical_but_equal(self):
         self.assertTrue([1, True], [1.0, complex(1, 0)])
+
+
+class BatchedTests(TestCase):
+    def test_basic(self):
+        zen = [
+            'Beautiful is better than ugly',
+            'Explicit is better than implicit',
+            'Simple is better than complex',
+            'Complex is better than complicated',
+            'Flat is better than nested',
+            'Sparse is better than dense',
+            'Readability counts',
+        ]
+        for size, expected in (
+            (
+                34,
+                [
+                    (zen[0],),
+                    (zen[1],),
+                    (zen[2],),
+                    (zen[3],),
+                    (zen[4],),
+                    (zen[5],),
+                    (zen[6],),
+                ],
+            ),
+            (
+                61,
+                [
+                    (zen[0], zen[1]),
+                    (zen[2],),
+                    (zen[3], zen[4]),
+                    (zen[5], zen[6]),
+                ],
+            ),
+            (
+                90,
+                [
+                    (zen[0], zen[1], zen[2]),
+                    (zen[3], zen[4], zen[5]),
+                    (zen[6],),
+                ],
+            ),
+            (
+                124,
+                [(zen[0], zen[1], zen[2], zen[3]), (zen[4], zen[5], zen[6])],
+            ),
+            (
+                150,
+                [(zen[0], zen[1], zen[2], zen[3], zen[4]), (zen[5], zen[6])],
+            ),
+            (
+                177,
+                [(zen[0], zen[1], zen[2], zen[3], zen[4], zen[5]), (zen[6],)],
+            ),
+        ):
+            with self.subTest(size=size):
+                actual = list(mi.batched(iter(zen), size))
+                self.assertEqual(actual, expected)
+
+    def test_strict(self):
+        iterable = ['1', '123456789', '1']
+        size = 8
+        with self.assertRaises(ValueError):
+            list(mi.batched(iterable, size))
+
+        actual = list(mi.batched(iterable, size, strict=False))
+        expected = [('1',), ('123456789',), ('1',)]
+        self.assertEqual(actual, expected)
+
+    def test_get_len(self):
+        class Record(tuple):
+            def total_size(self):
+                return sum(len(x) for x in self)
+
+        record_3 = Record(('1', '23'))
+        record_5 = Record(('1234', '1'))
+        record_10 = Record(('1', '12345678', '1'))
+        record_2 = Record(('1', '1'))
+        iterable = [record_3, record_5, record_10, record_2]
+
+        self.assertEqual(
+            list(mi.batched(iterable, 10, get_len=lambda x: x.total_size())),
+            [(record_3, record_5), (record_10,), (record_2,)],
+        )


### PR DESCRIPTION
This PR adds `batched`.

Suppose you're using Amazon SQS and want to send a bunch of messages with `boto3.client('sqs').send_message_batch()` ([ref](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.send_message_batch)). You've got a hard limit of 256 KiB for each batch, so you'll need to group them together such that each group's size doesn't exceed that limit. This function is designed to help you do (things like) that.