### PR TITLE
Issue 462: `windowed` should yield nothing for empty iterables

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -876,7 +876,9 @@ def windowed(seq, n, fillvalue=None, step=1):
             yield tuple(window)
 
     size = len(window)
-    if size < n:
+    if size == 0:
+        return
+    elif size < n:
         yield tuple(chain(window, repeat(fillvalue, n - size)))
     elif 0 < i < min(step, n):
         window += (fillvalue,) * i

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -783,64 +783,55 @@ class UniqueToEachTests(TestCase):
 
 
 class WindowedTests(TestCase):
-    """Tests for ``windowed()``"""
-
     def test_basic(self):
-        actual = list(mi.windowed([1, 2, 3, 4, 5], 3))
-        expected = [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
-        self.assertEqual(actual, expected)
-
-    def test_large_size(self):
-        """
-        When the window size is larger than the iterable, and no fill value is
-        given,``None`` should be filled in.
-        """
-        actual = list(mi.windowed([1, 2, 3, 4, 5], 6))
-        expected = [(1, 2, 3, 4, 5, None)]
-        self.assertEqual(actual, expected)
-
-    def test_fillvalue(self):
-        """
-        When sizes don't match evenly, the given fill value should be used.
-        """
         iterable = [1, 2, 3, 4, 5]
 
-        for n, kwargs, expected in [
-            (6, {}, [(1, 2, 3, 4, 5, '!')]),  # n > len(iterable)
-            (3, {'step': 3}, [(1, 2, 3), (4, 5, '!')]),  # using ``step``
-        ]:
-            actual = list(mi.windowed(iterable, n, fillvalue='!', **kwargs))
-            self.assertEqual(actual, expected)
+        for n, expected in (
+            (6, [(1, 2, 3, 4, 5, None)]),
+            (5, [(1, 2, 3, 4, 5)]),
+            (4, [(1, 2, 3, 4), (2, 3, 4, 5)]),
+            (3, [(1, 2, 3), (2, 3, 4), (3, 4, 5)]),
+            (2, [(1, 2), (2, 3), (3, 4), (4, 5)]),
+            (1, [(1,), (2,), (3,), (4,), (5,)]),
+            (0, [()]),
+        ):
+            with self.subTest(n=n):
+                actual = list(mi.windowed(iterable, n))
+                self.assertEqual(actual, expected)
 
-    def test_zero(self):
-        """When the window size is zero, an empty tuple should be emitted."""
-        actual = list(mi.windowed([1, 2, 3, 4, 5], 0))
-        expected = [tuple()]
+    def test_fillvalue(self):
+        actual = list(mi.windowed([1, 2, 3, 4, 5], 6, fillvalue='!'))
+        expected = [(1, 2, 3, 4, 5, '!')]
         self.assertEqual(actual, expected)
 
-    def test_negative(self):
-        """When the window size is negative, ValueError should be raised."""
-        with self.assertRaises(ValueError):
-            list(mi.windowed([1, 2, 3, 4, 5], -1))
-
     def test_step(self):
-        """The window should advance by the number of steps provided"""
         iterable = [1, 2, 3, 4, 5, 6, 7]
         for n, step, expected in [
             (3, 2, [(1, 2, 3), (3, 4, 5), (5, 6, 7)]),  # n > step
             (3, 3, [(1, 2, 3), (4, 5, 6), (7, None, None)]),  # n == step
-            (3, 4, [(1, 2, 3), (5, 6, 7)]),  # line up nicely
+            (3, 4, [(1, 2, 3), (5, 6, 7)]),  # lines up nicely
             (3, 5, [(1, 2, 3), (6, 7, None)]),  # off by one
             (3, 6, [(1, 2, 3), (7, None, None)]),  # off by two
             (3, 7, [(1, 2, 3)]),  # step past the end
             (7, 8, [(1, 2, 3, 4, 5, 6, 7)]),  # step > len(iterable)
         ]:
-            actual = list(mi.windowed(iterable, n, step=step))
-            self.assertEqual(actual, expected)
+            with self.subTest(n=n, step=step):
+                actual = list(mi.windowed(iterable, n, step=step))
+                self.assertEqual(actual, expected)
 
+    def test_invalid_step(self):
         # Step must be greater than or equal to 1
         with self.assertRaises(ValueError):
-            list(mi.windowed(iterable, 3, step=0))
+            list(mi.windowed([1, 2, 3, 4, 5], 3, step=0))
+
+    def test_fillvalue_step(self):
+        actual = list(mi.windowed([1, 2, 3, 4, 5], 3, fillvalue='!', step=3))
+        expected = [(1, 2, 3), (4, 5, '!')]
+        self.assertEqual(actual, expected)
+
+    def test_negative(self):
+        with self.assertRaises(ValueError):
+            list(mi.windowed([1, 2, 3, 4, 5], -1))
 
 
 class SubstringsTests(TestCase):


### PR DESCRIPTION
I was wrong on issue #462 and @cool-RR was right.

This PR makes `windowed` yield nothing on empty iterables.

The change will ship with `more-itertools` version 9.0.0, Real Soon Now.