### PR TITLE
Allow passing before_and_after remainders into before_and_after again

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -744,11 +744,12 @@ def before_and_after(predicate, it):
                 transition.append(elem)
                 return
 
-    def remainder_iterator():
-        yield from transition
-        yield from it
+    # Note: this is different from itertools recipes to allow nesting
+    # before_and_after remainders into before_and_after again. See tests
+    # for an example.
+    remainder_iterator = chain(transition, it)
 
-    return true_iterator(), remainder_iterator()
+    return true_iterator(), remainder_iterator
 
 
 def triplewise(iterable):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -799,7 +799,7 @@ class BeforeAndAfterTests(TestCase):
             # again, which would be problematic if the remainder is a
             # generator function (as in Python 3.10 itertools recipes), since
             # that creates recursion. `itertools.chain` solves this problem.
-            numbers, events = before_and_after(lambda e: isinstance(e, int), events)
+            numbers, events = mi.before_and_after(lambda e: isinstance(e, int), events)
 
             yield (operation, numbers)
     

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,6 +1,7 @@
 import warnings
 
 from doctest import DocTestSuite
+from functools import reduce
 from itertools import combinations, count, permutations
 from math import factorial
 from unittest import TestCase

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -799,7 +799,9 @@ class BeforeAndAfterTests(TestCase):
             # again, which would be problematic if the remainder is a
             # generator function (as in Python 3.10 itertools recipes), since
             # that creates recursion. `itertools.chain` solves this problem.
-            numbers, events = mi.before_and_after(lambda e: isinstance(e, int), events)
+            numbers, events = mi.before_and_after(
+                lambda e: isinstance(e, int), events
+            )
 
             yield (operation, numbers)
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -782,6 +782,35 @@ class BeforeAndAfterTests(TestCase):
         before, after = mi.before_and_after(bool, [1, True, 0, False])
         self.assertEqual(list(before), [1, True])
         self.assertEqual(list(after), [0, False])
+    
+    @staticmethod
+    def _group_events(events):
+        events = iter(events)
+
+        while True:
+            try:
+                operation = next(events)
+            except StopIteration:
+                break
+            assert operation in ["SUM", "MULTIPLY"]
+
+            # Here, the remainder `events` is passed into `before_and_after`
+            # again, which would be problematic if the remainder is a
+            # generator function (as in Python 3.10 itertools recipes), since
+            # that creates recursion. `itertools.chain` solves this problem.
+            numbers, events = before_and_after(lambda e: isinstance(e, int), events)
+
+            yield (operation, numbers)
+    
+    def test_nested_remainder(self):
+        events = ["SUM", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
+        events += ["MULTIPLY", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
+
+        for operation, numbers in self._group_events(events):
+            if operation == "SUM":
+                res = sum(numbers)
+            elif operation == "MULTIPLY":
+                res = reduce(lambda a, b: a * b, numbers)
 
 
 class TriplewiseTests(TestCase):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -783,7 +783,7 @@ class BeforeAndAfterTests(TestCase):
         before, after = mi.before_and_after(bool, [1, True, 0, False])
         self.assertEqual(list(before), [1, True])
         self.assertEqual(list(after), [0, False])
-    
+
     @staticmethod
     def _group_events(events):
         events = iter(events)
@@ -802,7 +802,7 @@ class BeforeAndAfterTests(TestCase):
             numbers, events = mi.before_and_after(lambda e: isinstance(e, int), events)
 
             yield (operation, numbers)
-    
+
     def test_nested_remainder(self):
         events = ["SUM", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
         events += ["MULTIPLY", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
@@ -810,8 +810,10 @@ class BeforeAndAfterTests(TestCase):
         for operation, numbers in self._group_events(events):
             if operation == "SUM":
                 res = sum(numbers)
+                self.assertEqual(res, 55)
             elif operation == "MULTIPLY":
                 res = reduce(lambda a, b: a * b, numbers)
+                self.assertEqual(res, 3628800)
 
 
 class TriplewiseTests(TestCase):


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
more-itertools/more-itertools#649

### Changes
This PR allows to pass the remainder of `before_and_after` into `before_and_after` again without triggering a `RecursionError`. See the linked issue and the new test for more info.
