### PR TITLE
Fix issue 658 for split_after

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1391,7 +1391,9 @@ def split_after(iterable, pred, maxsplit=-1):
         if pred(item) and buf:
             yield buf
             if maxsplit == 1:
-                yield list(it)
+                buf = list(it)
+                if buf:
+                    yield buf
                 return
             buf = []
             maxsplit -= 1

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1448,6 +1448,10 @@ class SplitAfterTest(TestCase):
                 ('a,b,c,d', lambda c: c != ',', 2),
                 [['a'], [',', 'b'], [',', 'c', ',', 'd']],
             ),
+            (
+                ([1], lambda x: x == 1, 1),
+                [[1]],
+            ),
         ]:
             actual = list(mi.split_after(*args))
             self.assertEqual(actual, expected)


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/658, this PR fixes `split_after` for `maxsplit==1`.