### PR TITLE
Update recipes.iter_index to match CPython PR 102360

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -830,9 +830,13 @@ def iter_index(iterable, value, start=0):
     except AttributeError:
         # Slow path for general iterables
         it = islice(iterable, start, None)
-        for i, element in enumerate(it, start):
-            if element is value or element == value:
+        i = start - 1
+        try:
+            while True:
+                i = i + operator.indexOf(it, value) + 1
                 yield i
+        except ValueError:
+            pass
     else:
         # Fast path for sequences
         i = start - 1


### PR DESCRIPTION
This PR updates `more_itertools.recipes.iter_index` to match https://github.com/python/cpython/pull/102360.

We still support Python 3.7, so we're not using the Walrus operator.