### PR TITLE
fixup remove 3.6 from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,38,39}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
commit 07447eacb16e5 restricted support to 3.7 but missed the tox envlist

### Changes
removes 36 from the tox envlist, since it is no longer supported