### PR TITLE
Optimize _chunked_even_finite()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4430,4 +4430,3 @@ def partial_product(*args):
         previous.append(current)
         current = future[0] if len(future) > 0 else None
         future = future[1:]
-

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4069,7 +4069,7 @@ def _chunked_even_finite(iterable, N, n):
     partial_start_idx = num_full * full_size
     if full_size > 0:
         for i in range(0, partial_start_idx, full_size):
-            yield list(iterable[i : i + full_size])
+            yield list(islice(iterable,i , i + full_size))
 
     # Yield num_partial lists of partial_size
     if partial_size > 0:
@@ -4078,7 +4078,7 @@ def _chunked_even_finite(iterable, N, n):
             partial_start_idx + (num_partial * partial_size),
             partial_size,
         ):
-            yield list(iterable[i : i + partial_size])
+            yield list(islice(iterable,i , i + partial_size))
 
 
 def zip_broadcast(*objects, scalar_types=(str, bytes), strict=False):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4069,7 +4069,7 @@ def _chunked_even_finite(iterable, N, n):
     partial_start_idx = num_full * full_size
     if full_size > 0:
         for i in range(0, partial_start_idx, full_size):
-            yield list(islice(iterable,i , i + full_size))
+            yield list(islice(iterable, i, i + full_size))
 
     # Yield num_partial lists of partial_size
     if partial_size > 0:
@@ -4078,7 +4078,7 @@ def _chunked_even_finite(iterable, N, n):
             partial_start_idx + (num_partial * partial_size),
             partial_size,
         ):
-            yield list(islice(iterable,i , i + partial_size))
+            yield list(islice(iterable, i, i + partial_size))
 
 
 def zip_broadcast(*objects, scalar_types=(str, bytes), strict=False):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4065,26 +4065,20 @@ def _chunked_even_finite(iterable, N, n):
     num_full = N - partial_size * num_lists
     num_partial = num_lists - num_full
 
-    buffer = []
-    iterator = iter(iterable)
-
     # Yield num_full lists of full_size
-    for x in iterator:
-        buffer.append(x)
-        if len(buffer) == full_size:
-            yield buffer
-            buffer = []
-            num_full -= 1
-            if num_full <= 0:
-                break
+    partial_start_idx = num_full * full_size
+    if full_size > 0:
+        for i in range(0, partial_start_idx, full_size):
+            yield list(iterable[i : i + full_size])
 
     # Yield num_partial lists of partial_size
-    for x in iterator:
-        buffer.append(x)
-        if len(buffer) == partial_size:
-            yield buffer
-            buffer = []
-            num_partial -= 1
+    if partial_size > 0:
+        for i in range(
+            partial_start_idx,
+            partial_start_idx + (num_partial * partial_size),
+            partial_size,
+        ):
+            yield list(iterable[i : i + partial_size])
 
 
 def zip_broadcast(*objects, scalar_types=(str, bytes), strict=False):
@@ -4436,3 +4430,4 @@ def partial_product(*args):
         previous.append(current)
         current = future[0] if len(future) > 0 else None
         future = future[1:]
+


### PR DESCRIPTION
### Issue reference

#698

### Changes

- Optimize **_chunked_even_finite** by yielding the chunk as a slice of the `iterable`, without using a for-loop to build up the chunk.

### Implementation Details

`yield list(islice(...))` was used to ensure that chunks for non-list iterables such as strings are yielded as lists, and to handle non-sliceable iterables like sets and dicts.

I used the following in IPython as a rudimentary benchmark.

**OS:** Linux x64 **CPU:** AMD Ryzen 7 5800X

```python
%timeit _ = [list(chunked_even(range(x), y)) for x in range(500) for y in range(1,500)]
# Before: 2.9 s ± 24.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# After: 1.39 s ± 12.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit _ = [list(chunked_even([z for z in range (x)], y)) for x in range(500) for y in range(1,500)]
# Before: 3.61 s ± 11.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# After: 1.91 s ± 19.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit _ = [list(chunked_even({z:z for z in range(x)}, y)) for x in range(500) for y in range(1,500)]
# Before: 4.33 s ± 34.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# After: 2.84 s ± 24.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit _ = [list(chunked_even(set(z for z in range(x)), y)) for x in range(500) for y in range(1,500)]
# Before: 4.31 s ± 26.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# After: 2.72 s ± 7.32 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

