### PR TITLE
Micro-op for interleave_evenly

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1133,7 +1133,7 @@ def interleave_evenly(iterables, lengths=None):
         yield next(iter_primary)
         to_yield -= 1
         # update errors for each secondary iterable
-        errors = [e - delta for e, delta in zip(errors, deltas_secondary)]
+        errors = list(map(sub, errors, deltas_secondary))
 
         # those iterables for which the error is negative are yielded
         # ("diagonal step" in Bresenham)


### PR DESCRIPTION
### Issue reference

Closes #701

### Changes

- Micro-optimization for **interleave_evenly**

### Implementation Details

Use `map` instead of `zip` as `map` is slightly faster for applying `operator.sub`.

Benchmarked as follows

**OS:** Linux x64 **CPU:** AMD Ryzen 7 5800X

```python
from more_itertools import interleave_evenly
%timeit list(interleave_evenly(([x for x in range(26)] * 100, [chr(ord('a') + x) for x in range(26)] * 100)))

Before: 1.1 ms ± 12 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
After : 895 µs ± 13.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

