### PR TITLE
Issue #707: fix ``iterate()`` to enable ``func`` to raise StopIteration + 3 unittests

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -475,7 +475,10 @@ def iterate(func, start):
     """
     while True:
         yield start
-        start = func(start)
+        try:
+            start = func(start)
+        except StopIteration:
+            break
 
 
 def with_iter(context_manager):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5388,3 +5388,34 @@ class PartialProductTests(TestCase):
         ]
 
         self.assertEqual(list(mi.partial_product('AB', 'C', 'DEF')), expected)
+
+
+class IterateTests(TestCase):
+    """Tests for ``iterate()``"""
+
+    def test_basic(self) -> None:
+        """Example from documentation"""
+        result = list(islice(mi.iterate(lambda x: 2 * x, start=1), 10))
+        expected = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+        self.assertEqual(result, expected)
+
+    def test_func_controls_iteration_stop(self) -> None:
+        """Issue #707: Now, ``func`` can stop iterate()."""
+
+        def func(num: int) -> int:
+            if num > 100:
+                raise StopIteration
+            return num * 2
+
+        result = list(islice(mi.iterate(func, start=1), 10))
+        expected = [1, 2, 4, 8, 16, 32, 64, 128]
+
+        self.assertEqual(result, expected)
+
+    def test_runtime_error_keeps_to_raise(self) -> None:
+        """Issue #707: Ensure yield keep it's generator behavior."""
+        generator = mi.iterate(lambda x: 2 * x, start=1)
+        next(generator)
+
+        with self.assertRaises(RuntimeError):
+            generator.throw(StopIteration)


### PR DESCRIPTION
### Issue reference
Resolves issue #707, as proposed by @bbayles. Without [``suppress()`` context manager](https://docs.python.org/3/library/contextlib.html#contextlib.suppress) and without ``accumulate`` + ``repeat()``

### Changes

1. The function ``func`` is now able to control iterations, using: ``raise StopIterator``, just like for ``accumulate()``.
2. 3 unit tests were added for ``iterate()``, in a new ``class IterateTests``.

```python
from random import randrange


def play_round(score: int) -> int:
    dice = randrange(1, 7)
    game_over = dice == 6
    if game_over:
        raise StopIteration
    return score + dice
``` 
```python
>>> from except_iterate import iterate
>>> from dice_game import play_round
>>> list(iterate(play_round, start=0))
[0, 4]
>>> list(iterate(play_round, start=0))
[0, 5, 9, 10, 12, 15]
``` 