### PR TITLE
Issue #677: Improve `partition`

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -442,11 +442,11 @@ def partition(pred, iterable):
     if pred is None:
         pred = bool
 
-    evaluations = ((pred(x), x) for x in iterable)
-    t1, t2 = tee(evaluations)
+    t1, t2, p = tee(iterable, 3)
+    p1, p2 = tee(map(pred, p))
     return (
-        (x for (cond, x) in t1 if not cond),
-        (x for (cond, x) in t2 if cond),
+        compress(t1, map(operator.not_, p1)),
+        compress(t2, p2)
     )
 
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -444,10 +444,7 @@ def partition(pred, iterable):
 
     t1, t2, p = tee(iterable, 3)
     p1, p2 = tee(map(pred, p))
-    return (
-        compress(t1, map(operator.not_, p1)),
-        compress(t2, p2)
-    )
+    return (compress(t1, map(operator.not_, p1)), compress(t2, p2))
 
 
 def powerset(iterable):


### PR DESCRIPTION
### Issue reference

more-itertools/more-itertools#677

### Changes

Improve `partition`, using `compress` instead of generator expressions.