### PR TITLE
Issue #713: Fix `partial_product` (also simplify and clean up)

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4502,7 +4502,7 @@ def gray_product(*iterables):
             f[j + 1] = j + 1
 
 
-def partial_product(*args):
+def partial_product(*iterables):
     """Yields tuples containing one item from each iterator, with subsequent
     tuples changing a single item at a time by advancing each iterator until it
     is exhausted. This sequence guarantees every value in each iterable is
@@ -4514,27 +4514,17 @@ def partial_product(*args):
         [('A', 'C', 'D'), ('B', 'C', 'D'), ('B', 'C', 'E'), ('B', 'C', 'F')]
     """
 
-    iterables = [iter(it) for it in args]
-
-    if len(iterables) == 0:
-        return
-
-    if len(iterables) == 1:
-        yield from iterables[0]
-        return
-
-    previous, current, future = [], [], []
+    iterators = list(map(iter, iterables))
 
     try:
-        current, *future = [next(i) for i in iterables]
+        future = [next(it) for it in iterators]
     except StopIteration:
-        raise ValueError("iterable must have at least one value.")
+        return
+    yield (*future,)
 
-    yield (*previous, current, *future)
-
-    for i in iterables:
-        for current in i:
+    previous = []
+    for it in iterators:
+        current = future.pop(0)
+        for current in it:
             yield (*previous, current, *future)
         previous.append(current)
-        current = future[0] if len(future) > 0 else None
-        future = future[1:]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5323,25 +5323,25 @@ class GrayProductTests(TestCase):
 
 
 class PartialProductTests(TestCase):
-    def test_empty(self):
-        self.assertEqual(tuple(mi.partial_product()), ())
+    def test_no_iterables(self):
+        self.assertEqual(tuple(mi.partial_product()), ((),))
 
-    def test_one_iterator(self):
+    def test_empty_iterable(self):
+        self.assertEqual(tuple(mi.partial_product('AB', '', 'CD')), ())
+
+    def test_one_iterable(self):
         # a single iterable should pass through
         self.assertEqual(
             tuple(mi.partial_product('ABCD')),
             (
-                'A',
-                'B',
-                'C',
-                'D',
+                ('A',),
+                ('B',),
+                ('C',),
+                ('D',),
             ),
         )
 
-    def test_two_iterators(self):
-        with self.assertRaises(ValueError):
-            list(mi.partial_product('ABCD', []))
-
+    def test_two_iterables(self):
         self.assertEqual(
             list(mi.partial_product('ABCD', [1])),
             [('A', 1), ('B', 1), ('C', 1), ('D', 1)],
@@ -5378,7 +5378,7 @@ class PartialProductTests(TestCase):
         actual = list(mi.partial_product(ones, tens, hundreds))
         self.assertEqual(actual, expected)
 
-    def test_uneven_length_lists(self):
+    def test_uneven_length_iterables(self):
         # this is also the docstring example
         expected = [
             ('A', 'C', 'D'),


### PR DESCRIPTION
### Issue reference

more-itertools/more-itertools#713

### Changes

- Fixes the bugs shown in the issue (both in the function and in its tests).
- Simplifies the code a bit (when and how `current` is taken from `future`).
- Fixes misnomers.
- Removes dead code.