### PR TITLE
Add configuration file for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
This PR adds a configuration file for ReadTheDocs, as described in [this blog post](https://blog.readthedocs.com/migrate-configuration-v2/).