### PR TITLE
Speed up `zip_broadcast()` by pre-filling the scalar elements

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4239,16 +4239,14 @@ def zip_broadcast(*objects, scalar_types=(str, bytes), strict=False):
         yield tuple(objects)
         return
 
+    new_item = [None] * size
+    for i, elem in zip(scalar_positions, scalars):
+        new_item[i] = elem
+
     zipper = _zip_equal if strict else zip
     for item in zipper(*iterables):
-        new_item = [None] * size
-
         for i, elem in zip(iterable_positions, item):
             new_item[i] = elem
-
-        for i, elem in zip(scalar_positions, scalars):
-            new_item[i] = elem
-
         yield tuple(new_item)
 
 


### PR DESCRIPTION
#737 got me thinking about how to speed up `zip_broadcast()`, and one simple optimization I noticed is that there's no need to initialize the `new_item` list and fill in all the scalar values on every iteration.  That only needs to be done once up front, since the loop will only ever alter the positions in `new_item` associated with the iterable arguments.

For the example given in #737, this new version is twice as fast as the old version:

New version:
```
>>> timeit('consume(zip_broadcast("_", "__", [1] * 100_000, [222] * 200_000))', globals=globals(), number=10)
0.45314044202677906
```
Old version:
```
>>> timeit('consume(zip_broadcast("_", "__", [1] * 100_000, [222] * 200_000))', globals=globals(), number=10)
1.0282995470333844
```
