### PR TITLE
Simplify `zip_broadcast`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4226,28 +4226,23 @@ def zip_broadcast(*objects, scalar_types=(str, bytes), strict=False):
     if not size:
         return
 
+    new_item = [None] * size
     iterables, iterable_positions = [], []
-    scalars, scalar_positions = [], []
     for i, obj in enumerate(objects):
         if is_scalar(obj):
-            scalars.append(obj)
-            scalar_positions.append(i)
+            new_item[i] = obj
         else:
             iterables.append(iter(obj))
             iterable_positions.append(i)
 
-    if len(scalars) == size:
+    if not iterables:
         yield tuple(objects)
         return
 
-    new_item = [None] * size
-    for i, elem in zip(scalar_positions, scalars):
-        new_item[i] = elem
-
     zipper = _zip_equal if strict else zip
     for item in zipper(*iterables):
-        for i, elem in zip(iterable_positions, item):
-            new_item[i] = elem
+        for i, new_item[i] in zip(iterable_positions, item):
+            pass
         yield tuple(new_item)
 
 


### PR DESCRIPTION
No need to build `scalars` and `scalar_positions`. Just put the scalars into `new_item` directly. (And a little optimization in the main loop, removing a detour through an extra variable).

@kalekundert

### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
<!-- Not all proposals for new functionality will be accepted, so please save yourself some work by checking first with an issue -->
more-itertools/more-itertools#XXXX

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
