### PR TITLE
Simplify `_zip_equal`

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -347,18 +347,13 @@ def _zip_equal(*iterables):
         for i, it in enumerate(iterables[1:], 1):
             size = len(it)
             if size != first_size:
-                break
-        else:
-            # If we didn't break out, we can use the built-in zip.
-            return zip(*iterables)
-
-        # If we did break out, there was a mismatch.
-        raise UnequalIterablesError(details=(first_size, i, size))
+                raise UnequalIterablesError(details=(first_size, i, size))
+        # All sizes are equal, we can use the built-in zip.
+        return zip(*iterables)
     # If any one of the iterables didn't have a length, start reading
     # them until one runs out.
     except TypeError:
         return _zip_equal_generator(iterables)
-
 
 def grouper(iterable, n, incomplete='fill', fillvalue=None):
     """Group elements from *iterable* into fixed-length groups of length *n*.

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -355,6 +355,7 @@ def _zip_equal(*iterables):
     except TypeError:
         return _zip_equal_generator(iterables)
 
+
 def grouper(iterable, n, incomplete='fill', fillvalue=None):
     """Group elements from *iterable* into fixed-length groups of length *n*.
 


### PR DESCRIPTION
### Changes

Raise right away instead of `break`ing just to fall into the `raise` and having to `else`-escape the good case.