### PR TITLE
Test latest Python 3.12 prerelease

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-beta.4", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]
 
     steps:
     - uses: actions/checkout@v3
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -160,10 +160,8 @@ class LastTests(TestCase):
             (iter(range(1)), 0),
             (IterOnlyRange(5), 4),
             ({n: str(n) for n in range(5)}, 4),
+            ({0: '0', -1: '-1', 2: '-2'}, 2),
         ]
-        # Versions below 3.6.0 don't have ordered dicts
-        if version_info >= (3, 6, 0):
-            cases.append(({0: '0', -1: '-1', 2: '-2'}, 2))
 
         for iterable, expected in cases:
             with self.subTest(iterable=iterable):
@@ -3259,7 +3257,6 @@ class DifferenceTest(TestCase):
     def test_empty(self):
         self.assertEqual(list(mi.difference([])), [])
 
-    @skipIf(version_info[:2] < (3, 8), 'accumulate with initial needs 3.8+')
     def test_initial(self):
         original = list(range(100))
         accumulated = accumulate(original, initial=100)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}
+envlist = py{38,39,310,311,312}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
<!-- Not all proposals for new functionality will be accepted, so please save yourself some work by checking first with an issue -->
more-itertools/more-itertools#XXXX

Does this need an issue?

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->


Instead of pinning to 3.12.0 beta 4, test against the latest available. Right now that's RC1, with RC2 due tomorrow or soon after. And when the full release comes out next month, it'll test that. Also add 3.12 Trove classifier and remove some redundant conditionals.