### PR TITLE
Issue 735: iter_suppress

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -191,6 +191,7 @@ These tools yield certain items from an iterable.
 .. autofunction:: rstrip
 .. autofunction:: filter_except
 .. autofunction:: map_except
+.. autofunction:: iter_suppress
 .. autofunction:: nth_or_last(iterable, n[, default])
 .. autofunction:: unique_in_window
 .. autofunction:: duplicates_everseen

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -83,6 +83,7 @@ __all__ = [
     'is_sorted',
     'islice_extended',
     'iterate',
+    'iter_suppress',
     'last',
     'locate',
     'longest_common_prefix',
@@ -4567,3 +4568,37 @@ def outer_product(func, xs, ys, *args, **kwargs):
         starmap(lambda x, y: func(x, y, *args, **kwargs), product(xs, ys)),
         n=len(ys),
     )
+
+
+def iter_suppress(iterable, *exceptions):
+    """Yield each of the items from *iterable*. If the iteration raises one of
+    the specified *exceptions*, that exception will be suppressed and iteration
+    will stop.
+
+    >>> from itertools import chain
+    >>> def breaks_at_five(x):
+    ...     while True:
+    ...         if x >= 5:
+    ...             raise RuntimeError
+    ...         yield x
+    ...         x += 1
+    >>> it_1 = iter_suppress(breaks_at_five(1), RuntimeError)
+    >>> it_2 = iter_suppress(breaks_at_five(2), RuntimeError)
+    >>> list(chain(it_1, it_2))
+    [1, 2, 3, 4, 2, 3, 4]
+    """
+    try:
+        it = iter(iterable)
+    except exceptions:
+        return
+
+    while True:
+        try:
+            item = next(it, _marker)
+        except exceptions:
+            break
+
+        if item is _marker:
+            break
+
+        yield item

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4588,17 +4588,6 @@ def iter_suppress(iterable, *exceptions):
     [1, 2, 3, 4, 2, 3, 4]
     """
     try:
-        it = iter(iterable)
+        yield from iterable
     except exceptions:
         return
-
-    while True:
-        try:
-            item = next(it, _marker)
-        except exceptions:
-            break
-
-        if item is _marker:
-            break
-
-        yield item

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -682,3 +682,7 @@ def outer_product(
     *args: Any,
     **kwargs: Any,
 ) -> Iterator[tuple[_V, ...]]: ...
+def iter_suppress(
+    iterable: Iterable[_T],
+    *exceptions: Type[BaseException],
+) -> Iterator[_T]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5479,3 +5479,47 @@ class OuterProductTests(TestCase):
             ('Goodbye, Alice!', 'Goodbye, Bob!', 'Goodbye, Carol!'),
         ]
         self.assertEqual(result, expected)
+
+
+class IterSuppressTests(TestCase):
+    class Producer:
+        def __init__(self, exc, die_early=False):
+            self.exc = exc
+            self.pos = 0
+            self.die_early = die_early
+
+        def __iter__(self):
+            if self.die_early:
+                raise self.exc
+
+            return self
+
+        def __next__(self):
+            ret = self.pos
+            if self.pos >= 5:
+                raise self.exc
+            self.pos += 1
+            return ret
+
+    def test_no_error(self):
+        iterator = range(5)
+        actual = list(mi.iter_suppress(iterator, RuntimeError))
+        expected = [0, 1, 2, 3, 4]
+        self.assertEqual(actual, expected)
+
+    def test_raises_error(self):
+        iterator = self.Producer(ValueError)
+        with self.assertRaises(ValueError):
+            list(mi.iter_suppress(iterator, RuntimeError))
+
+    def test_suppression(self):
+        iterator = self.Producer(ValueError)
+        actual = list(mi.iter_suppress(iterator, RuntimeError, ValueError))
+        expected = [0, 1, 2, 3, 4]
+        self.assertEqual(actual, expected)
+
+    def test_early_suppression(self):
+        iterator = self.Producer(ValueError, die_early=True)
+        actual = list(mi.iter_suppress(iterator, RuntimeError, ValueError))
+        expected = []
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/735, this PR adds `iter_suppress`.

Per [the discussion](https://github.com/more-itertools/more-itertools/issues/735#issuecomment-1703986485), the new function converts a user-specified exception into something equivalent to `StopIteration`.