### PR TITLE
Add stop argument to iter_index

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -817,35 +817,34 @@ def polynomial_from_roots(roots):
     return list(reduce(convolve, factors, [1]))
 
 
-def iter_index(iterable, value, start=0):
+def iter_index(iterable, value, start=0, stop=None):
     """Yield the index of each place in *iterable* that *value* occurs,
-    beginning with index *start*.
+    beginning with index *start* and ending before index *stop*.
 
     See :func:`locate` for a more general means of finding the indexes
     associated with particular values.
 
     >>> list(iter_index('AABCADEAF', 'A'))
     [0, 1, 4, 7]
+    >>> list(iter_index('AABCADEAF', 'A', 1))  # start index is inclusive
+    [1, 4, 7]
+    >>> list(iter_index('AABCADEAF', 'A', 1, 7))  # stop index is not inclusive
+    [1, 4]
     """
-    try:
-        seq_index = iterable.index
-    except AttributeError:
+    seq_index = getattr(iterable, 'index', None)
+    if seq_index is None:
         # Slow path for general iterables
-        it = islice(iterable, start, None)
-        i = start - 1
-        try:
-            while True:
-                i = i + operator.indexOf(it, value) + 1
+        it = islice(iterable, start, stop)
+        for i, element in enumerate(it, start):
+            if element is value or element == value:
                 yield i
-        except ValueError:
-            pass
     else:
         # Fast path for sequences
+        stop = len(iterable) if stop is None else stop
         i = start - 1
         try:
             while True:
-                i = seq_index(value, i + 1)
-                yield i
+                yield (i := seq_index(value, i + 1, stop))
         except ValueError:
             pass
 

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -108,6 +108,7 @@ def iter_index(
     iterable: Iterable[_T],
     value: Any,
     start: int | None = ...,
+    stop: int | None = ...,
 ) -> Iterator[int]: ...
 def sieve(n: int) -> Iterator[int]: ...
 def batched(

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -931,6 +931,12 @@ class IterIndexTests(TestCase):
                 expected = [0, 1, 4, 7]
                 self.assertEqual(actual, expected)
 
+    def test_stop(self):
+        iterable = 'AABCADEAF'
+        actual = list(mi.iter_index('AABCADEAF', 'A', stop=7))
+        expected = [0, 1, 4]
+        self.assertEqual(actual, expected)
+
 
 class SieveTests(TestCase):
     def test_basic(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -932,7 +932,6 @@ class IterIndexTests(TestCase):
                 self.assertEqual(actual, expected)
 
     def test_stop(self):
-        iterable = 'AABCADEAF'
         actual = list(mi.iter_index('AABCADEAF', 'A', stop=7))
         expected = [0, 1, 4]
         self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR updates `iter_index` to match the [current itertools docs](https://github.com/python/cpython/pull/109306).