### PR TITLE
Issue 760: Fix all_equal typo

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3356,7 +3356,7 @@ def iequals(*iterables):
     >>> iequals("abc", "acb")
     False
 
-    Not to be confused with :func:`all_equals`, which checks whether all
+    Not to be confused with :func:`all_equal`, which checks whether all
     elements of iterable are equal to each other.
 
     """


### PR DESCRIPTION
See https://github.com/more-itertools/more-itertools/issues/760 . Thanks to @F-park .