### PR TITLE
Update versions.rst to clarify 9.0.0 dropping support for previous ve…

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -74,7 +74,7 @@ Version History
     * :func:`grouper` no longer accepts an integer as its first argument. Previously this raised a ``DeprecationWarning``.
     * :func:`collate` has been removed. Use the built-in :func:`heapq.merge` instead.
     * :func:`windowed` now yields nothing when its iterable is empty.
-    * This library now advertises support for Python 3.7+.
+    * This library now advertises support for Python 3.7+; previous versions are no longer supported.
 
 * New functions
     * :func:`constrained_batches`


### PR DESCRIPTION
This confused me, because it sounded like v9.0.0 only adds support for new versions; it was unclear that it is actually dropping support for older versions.