### PR TITLE
Filter_map  implementation

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -70,6 +70,7 @@ __all__ = [
     'duplicates_justseen',
     'exactly_n',
     'filter_except',
+    'filter_map',
     'first',
     'gray_product',
     'groupby_transform',
@@ -4590,3 +4591,17 @@ def iter_suppress(iterable, *exceptions):
         yield from iterable
     except exceptions:
         return
+
+
+def filter_map(func, iterable):
+    """Apply ``func`` to every element of ``iterable`, yielding only those
+       which are not ``None``.
+
+    >>> elems = ['1', 'a', '2', 'b', '3']
+    >>> list(filter_map(lambda s: int(s) if s.isnumeric() else None, elems))
+    [1, 2, 3]
+    """
+    for x in iterable:
+        y = func(x)
+        if y is not None:
+            yield y

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -686,3 +686,7 @@ def iter_suppress(
     iterable: Iterable[_T],
     *exceptions: Type[BaseException],
 ) -> Iterator[_T]: ...
+def filter_map(
+    func: Callable[[_T], _V | None],
+    iterable: Iterable[_T],
+) -> Iterator[_V]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5515,3 +5515,25 @@ class IterSuppressTests(TestCase):
         actual = list(mi.iter_suppress(iterator, RuntimeError, ValueError))
         expected = []
         self.assertEqual(actual, expected)
+
+class FilterMapTests(TestCase):
+    def test_no_iterables(self):
+        actual = list(mi.filter_map(lambda _: None, []))
+        expected = []
+        self.assertEqual(actual, expected)
+
+    def test_filter(self):
+        actual = list(mi.filter_map(lambda _: None, [1, 2, 3]))
+        expected = []
+        self.assertEqual(actual, expected)
+
+    def test_map(self):
+        actual = list(mi.filter_map(lambda x: x+1, [1, 2, 3]))
+        expected = [2, 3, 4]
+        self.assertEqual(actual, expected)
+
+    def test_filter_map(self):
+        actual = list(mi.filter_map(lambda x:int(x) if x.isnumeric() else None,
+                      ['1', 'a', '2', 'b', '3']))
+        expected = [1, 2, 3]
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#763

### Changes

- Implements `filter_map`, a combination of both filter and map operations.

