### PR TITLE
Fix formatting of matmul and factor examples in recipes.py

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -911,6 +911,7 @@ def transpose(it):
 
 def matmul(m1, m2):
     """Multiply two matrices.
+
     >>> list(matmul([(7, 5), (3, 5)], [(2, 5), (7, 9)]))
     [(49, 80), (41, 60)]
 
@@ -923,6 +924,7 @@ def matmul(m1, m2):
 
 def factor(n):
     """Yield the prime factors of n.
+
     >>> list(factor(360))
     [2, 2, 2, 3, 3, 5]
     """


### PR DESCRIPTION
### Changes

Fix formatting of examples for matmul and factor in recipes.py

Current rendering:
![Screenshot 2023-10-20 at 14 32 30](https://github.com/more-itertools/more-itertools/assets/9333950/4172c805-73a1-4070-96ef-97924eea697d)

Thanks for the awesome library!