### PR TITLE
docs: add sphinx_rtd_theme to docs/requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,7 @@ build:
 
 sphinx:
    configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 Sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
### Issue reference
fix #768

### Changes
This PR adds explicit dependency to `sphinx_rtd_theme` which is the missing one during the build. Also, I specified `requirements.txt` in `.readthedocs.yaml` following the documentation of Read the Docs[^1] (maybe it's be better to pin the package version as well). That should ensure installing dependencies.

[^1]: [How to create reproducible builds — Read the Docs user documentation](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#id6)
