### PR TITLE
Remove minor duplication in takewhile_inclusive

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4530,10 +4530,8 @@ def takewhile_inclusive(predicate, iterable):
     :func:`takewhile` would return ``[1, 4]``.
     """
     for x in iterable:
-        if predicate(x):
-            yield x
-        else:
-            yield x
+        yield x
+        if not predicate(x):
             break
 
 


### PR DESCRIPTION
Pull `yield x` out because it's used in both branches of if/else.
