### PR TITLE
Optimize combination_with_replacement_index

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4067,8 +4067,10 @@ def combination_with_replacement_index(element, iterable):
         occupations[p] += 1
 
     index = 0
+    cumulative_sum = 0
     for k in range(1, n):
-        j = l + n - 1 - k - sum(occupations[:k])
+        cumulative_sum += occupations[k-1]
+        j = l + n - 1 - k - cumulative_sum
         i = n - k
         if i <= j:
             index += factorial(j) // (factorial(i) * factorial(j - i))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4069,7 +4069,7 @@ def combination_with_replacement_index(element, iterable):
     index = 0
     cumulative_sum = 0
     for k in range(1, n):
-        cumulative_sum += occupations[k-1]
+        cumulative_sum += occupations[k - 1]
         j = l + n - 1 - k - cumulative_sum
         i = n - k
         if i <= j:


### PR DESCRIPTION
### Issue reference

Closes #772

### Changes

- Optimize **combination_with_replacement_index** by using an accumulating loop variable instead of summing up all elements up to index k per loop iteration

### Benchmarks

I used the following in IPython as a rudimentary benchmark.

**OS:** Linux x64 **CPU:** AMD Ryzen 7 5800X

```python
from more_itertools import combination_with_replacement_index
%timeit combination_with_replacement_index('adf', 'abcdefg')
# Before: 1.96 µs ± 9.67 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
# After: 1.56 µs ± 3.66 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```


