### PR TITLE
Fix typo in `bucket` docstring

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -921,7 +921,7 @@ def substrings_indexes(seq, reverse=False):
 
 
 class bucket:
-    """Wrap *iterable* and return an object that buckets it iterable into
+    """Wrap *iterable* and return an object that buckets the iterable into
     child iterables based on a *key* function.
 
         >>> iterable = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'b3']


### PR DESCRIPTION
The original wording seems wrong to me, so here is an attempt to fix it.

Maybe "[…] that buckets it [the iterable] into child iterables […]" was meant, but since "it" could also mean "the object", I find my suggestion to be arguably less ambiguous.