### PR TITLE
Add a strict argument for batched

### DIFF
--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -112,10 +112,7 @@ def iter_index(
 ) -> Iterator[int]: ...
 def sieve(n: int) -> Iterator[int]: ...
 def batched(
-    iterable: Iterable[_T],
-    n: int,
-    *,
-    strict: bool = False
+    iterable: Iterable[_T], n: int, *, strict: bool = False
 ) -> Iterator[tuple[_T]]: ...
 def transpose(
     it: Iterable[Iterable[_T]],

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -114,6 +114,8 @@ def sieve(n: int) -> Iterator[int]: ...
 def batched(
     iterable: Iterable[_T],
     n: int,
+    *,
+    strict: bool = False
 ) -> Iterator[tuple[_T]]: ...
 def transpose(
     it: Iterable[Iterable[_T]],

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -999,6 +999,15 @@ class BatchedTests(TestCase):
                 actual = list(mi.batched(iterable, n))
                 self.assertEqual(actual, expected)
 
+    def test_strict(self):
+        with self.assertRaises(ValueError):
+            list(mi.batched('ABCDEFG', 3, strict=True))
+
+        self.assertEqual(
+            list(mi.batched('ABCDEF', 3, strict=True)),
+            [('A', 'B', 'C'), ('D', 'E', 'F')],
+        )
+
 
 class TransposeTests(TestCase):
     def test_empty(self):


### PR DESCRIPTION
This PR synchronizes `batched` with https://github.com/python/cpython/pull/113203.

Previously, `itertools.batched` was used for Python 3.12+. This no longer works, since Python 3.13's version will have this new feature.

Therefore, now Python 3.13+ will use `itertools.batched` and all previous versions of Python will use `more_itertools.more.batched`.