### PR TITLE
Makefile tweaks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ more-itertools/more-itertools#XXXX
 <!-- Describe what your PR adds, fixes, or changes here -->
 
 ### Checks and tests
-<!-- Please run `make format`, `make check`, and `make test` to help make sure your branch meets the standards enforced by GitHub Actions -->
+<!-- Please run `make all-checks` to help make sure your branch meets the standards enforced by GitHub Actions. -->

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,24 +18,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
     - name: Install dependencies
-      run: |
-        make requirements
+      run: make requirements
     - name: Run tests
-      run: |
-        make coverage
+      run: make coverage
     - name: Static checks
       if: "matrix.python-version == '3.8'"
-      run: |
-        make check
-        black --check .
+      run: make check
     - name: Build docs with sphinx
       if: "matrix.python-version == '3.8'"
-      run: |
-        make docs
+      run: make docs
     - name: Build packages
       if: "matrix.python-version == '3.8'"
-      run: |
-        make package
+      run: make package
     - name: Upload packages
       if: "matrix.python-version == '3.8'"
       uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all-checks
+all-checks: requirements coverage check docs package
+
 .PHONY: requirements
 requirements:
 	python3 -m pip install -r requirements/development.txt

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: requirements
 requirements:
 	python3 -m pip install -r requirements/development.txt
-	python -m pip install -e .
+	python3 -m pip install --editable .
 
 .PHONY: check
 check:
@@ -20,7 +20,7 @@ coverage:
 
 .PHONY: test
 test:
-	python -m unittest -v ${tests}
+	python3 -m unittest -v ${tests}
 
 .PHONY: docs
 docs:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ coverage:
 
 .PHONY: test
 test:
-	python3 -m unittest -v ${tests}
+	python3 -m unittest -v
 
 .PHONY: docs
 docs:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ requirements:
 .PHONY: check
 check:
 	black --check .
-	flake8 .
+	flake8 --exclude .venv,venv,docs/conf.py .
 	stubtest more_itertools.more more_itertools.recipes
 
 .PHONY: format


### PR DESCRIPTION
Thanks for #785! This PR includes several fixes and tweaks:

- Fix the `flake8` step when used with `venv`
- Remove a redundant `black --check .` in the workflow
- Remove an unused variable in the Makefile
- Add a `make all-checks` for simplicity
- Always call `python3` (`python` can still be Python 2 on some older systems)
- Slight reformatting of workflow file (easier to read IMHO, and might encourage new steps to be added to Makefile instead of the workflow)