### PR TITLE
Issue 787: update strictly_n docstring

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -584,6 +584,9 @@ def strictly_n(iterable, n, too_short=None, too_long=None):
         >>> list(strictly_n(iterable, n))
         ['a', 'b', 'c', 'd']
 
+    Note that the returned iterable must be consumed in order for the check to be
+    made.
+
     By default, *too_short* and *too_long* are functions that raise
     ``ValueError``.
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -584,8 +584,8 @@ def strictly_n(iterable, n, too_short=None, too_long=None):
         >>> list(strictly_n(iterable, n))
         ['a', 'b', 'c', 'd']
 
-    Note that the returned iterable must be consumed in order for the check to be
-    made.
+    Note that the returned iterable must be consumed in order for the check to
+    be made.
 
     By default, *too_short* and *too_long* are functions that raise
     ``ValueError``.


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/787, this PR updates the docstring for `strictly_n` to clarify the current behavior.

Thanks @kujenga!