### PR TITLE
Ensure time_limited(0, ...) always returns nothing

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3227,6 +3227,8 @@ class time_limited:
     stops if  the time elapsed is greater than *limit_seconds*. If your time
     limit is 1 second, but it takes 2 seconds to generate the first item from
     the iterable, the function will run for 2 seconds and not yield anything.
+    As a special case, when *limit_seconds* is zero, the iterator never
+    returns anything.
 
     """
 
@@ -3242,6 +3244,9 @@ class time_limited:
         return self
 
     def __next__(self):
+        if self.limit_seconds == 0:
+            self.timed_out = True
+            raise StopIteration
         item = next(self._iterable)
         if monotonic() - self._start_time > self.limit_seconds:
             self.timed_out = True


### PR DESCRIPTION
As per the [tests](https://github.com/more-itertools/more-itertools/blob/91a38218a99e633768c5cfc3010ef0d246017f2e/tests/test_more.py#L3904), this is the intended behavior, but it does not actually work if `monotonic()` returns the same value twice (e.g. on Windows).

It bugs me a little bit that I have to repeat the `self.timed_out = True` and `raise StopIteration` lines, but I guess doing `item = next(self._iterable)` before the time check is the intended behavior. I also chose not to simply change `if monotonic() - self._start_time > self.limit_seconds:` to a `>=` because I think that could at least theoretically suffer from floating-point issues.