### PR TITLE
100% Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ pip-log.txt
 .coverage
 .tox
 .noseids
+htmlcov/
+coverage.xml
 
 # Docs by Sphinx
 _build

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ format:
 .PHONY: coverage
 coverage:
 	coverage run --include="more_itertools/*.py" -m unittest
-	coverage report --show-missing --fail-under=99
+	coverage report --show-missing --fail-under=100
 
 .PHONY: test
 test:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1649,7 +1649,7 @@ def zip_equal(*iterables):
         lengths
 
     """
-    if hexversion >= 0x30A00A6:
+    if hexversion >= 0x30A00A6:  # pragma: no cover
         warnings.warn(
             (
                 'zip_equal will be removed in a future version of '

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3859,15 +3859,13 @@ def nth_permutation(iterable, r, index):
         raise ValueError
     else:
         c = perm(n, r)
+    assert c > 0  # factortial(n)>0, and r<n so perm(n,r) is never zero
 
     if index < 0:
         index += c
 
     if not 0 <= index < c:
         raise IndexError
-
-    if c == 0:
-        return tuple()
 
     result = [0] * r
     q = index * factorial(n) // c if r < n else index

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -84,9 +84,9 @@ _marker = object()
 # zip with strict is available for Python 3.10+
 try:
     zip(strict=True)
-except TypeError:
+except TypeError:  # pragma: no cover
     _zip_strict = zip
-else:
+else:  # pragma: no cover
     _zip_strict = partial(zip, strict=True)
 
 # math.sumprod is available for Python 3.12+
@@ -314,9 +314,9 @@ def _pairwise(iterable):
 
 try:
     from itertools import pairwise as itertools_pairwise
-except ImportError:
+except ImportError:  # pragma: no cover
     pairwise = _pairwise
-else:
+else:  # pragma: no cover
 
     def pairwise(iterable):
         return itertools_pairwise(iterable)
@@ -893,7 +893,7 @@ def _batched(iterable, n, *, strict=False):
         yield batch
 
 
-if hexversion >= 0x30D00A2:
+if hexversion >= 0x30D00A2:  # pragma: no cover
     from itertools import batched as itertools_batched
 
     def batched(iterable, n, *, strict=False):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5494,6 +5494,10 @@ class ConstrainedBatchesTests(TestCase):
             [(record_3, record_5), (record_10,), (record_2,)],
         )
 
+    def test_bad_max(self):
+        with self.assertRaises(ValueError):
+            list(mi.constrained_batches([], 0))
+
 
 class GrayProductTests(TestCase):
     def test_basic(self):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -772,6 +772,11 @@ class WindowedTests(TestCase):
         with self.assertRaises(ValueError):
             list(mi.windowed([1, 2, 3, 4, 5], -1))
 
+    def test_empty_seq(self):
+        actual = list(mi.windowed([], 3))
+        expected = []
+        self.assertEqual(actual, expected)
+
 
 class SubstringsTests(TestCase):
     def test_basic(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -268,6 +268,12 @@ class PairwiseTests(TestCase):
         p = mi.pairwise("a")
         self.assertRaises(StopIteration, lambda: next(p))
 
+    def test_coverage(self):
+        from more_itertools import recipes
+
+        p = recipes._pairwise([1, 2, 3])
+        self.assertEqual([(1, 2), (2, 3)], list(p))
+
 
 class GrouperTests(TestCase):
     def test_basic(self):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -698,7 +698,7 @@ class NthPermutationTests(TestCase):
         n = factorial(len(iterable)) // factorial(len(iterable) - r)
         for index in [-1 - n, n + 1]:
             with self.assertRaises(IndexError):
-                mi.nth_combination(iterable, r, index)
+                mi.nth_permutation(iterable, r, index)
 
     def test_invalid_r(self):
         iterable = 'abcde'
@@ -706,7 +706,7 @@ class NthPermutationTests(TestCase):
         n = factorial(len(iterable)) // factorial(len(iterable) - r)
         for r in [-1, n + 1]:
             with self.assertRaises(ValueError):
-                mi.nth_combination(iterable, r, 0)
+                mi.nth_permutation(iterable, r, 0)
 
 
 class PrependTests(TestCase):


### PR DESCRIPTION
This PR increases the code coverage to 100% (and ups the required code coverage accordingly), tested on Python 3.8 to 3.12 on Linux. Note this includes a few actual fixes:

- 6d60ae231b9d3eb9a65f808bf59c9b6a7916dcfa: Corrects `NthPermutationTests` (some tests accidentally referred to `nth_combination` instead)
- a1c7e6611a6f75700b7e9f524d994f97ecf3a47c: Removes unreachable code in `nth_permutation`

I chose to simply suppress coverage on a few bits of version-dependent code. As a side note, there is an alternative that I [use](https://github.com/haukex/igbpyutils/blob/58ba2a92a612a06223f045d5dc9d26fdf3686e54/prove.sh#L11) in my `igbpyutils` project: [Generated](https://igbpyutils.readthedocs.io/en/stable/dev.html#igbpyutils.dev.generate_coveragerc) `.coveragerc` files with tags such as `# cover-req-ge3.10` and `# cover-req-lt3.10` for each Python version. This allows me to run Python version-specific coverage checks in that project.
