### PR TITLE
Speed up `ichunked`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3352,13 +3352,16 @@ def ichunked(iterable, n):
         raise ValueError('n must be a positive integer')
     
     while True:
+        # Create new chunk
         (chunk, materialize_next) = _ichunk(iterable, n)
 
+        # Check to see whether we're at the end of the source iterable
         if not materialize_next():
             return
 
         yield chunk
 
+        # Fill previous chunk's cache
         materialize_next(None)
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3313,9 +3313,6 @@ def _ichunk(iterable, n):
                     yield item
 
     def materialize_next(n = 1):
-        if n and n < 0:
-            raise ValueError('n must be >= 0 or None')
-        
         inital_cache_len = len(cache)
 
         if n is None:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3346,11 +3346,7 @@ def ichunked(iterable, n):
     [8, 9, 10, 11]
 
     """
-
     iterable = iter(iterable)
-    if not n or n <= 0:
-        raise ValueError('n must be a positive integer')
-    
     while True:
         # Create new chunk
         (chunk, materialize_next) = _ichunk(iterable, n)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3313,21 +3313,18 @@ def _ichunk(iterable, n):
                     yield item
 
     def materialize_next(n=1):
-        # materialize everything if n not specified
+        # if n not specified materialize everything
         if n is None:
             cache.extend(chunk)
             return len(cache)
 
-        inital_cache_len = len(cache)
-
-        # check if we need to materialize any
-        if n <= inital_cache_len:
-            return n
+        to_cache = n - len(cache)
 
         # materialize up to n
-        cache.extend(islice(chunk, n - inital_cache_len))
+        if to_cache > 0:
+            cache.extend(islice(chunk, to_cache))
 
-        # return num materialized up to n
+        # return number materialized up to n
         return min(n, len(cache))
 
     return (generator(), materialize_next)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3984,22 +3984,41 @@ class IchunkedTests(TestCase):
         self.assertRaises(RuntimeError, next, it)
 
     def test_memory_in_order(self):
-        # No items should be kept in memory when a chunk is produced
-        all_chunks = mi.ichunked(count(), 4)
+        gen_numbers = []
+
+        def gen():
+            for gen_number in count():
+                gen_numbers.append(gen_number)
+                yield gen_number
+
+        # No items should be kept in memory when a ichunked is first called
+        all_chunks = mi.ichunked(gen(), 4)
+        self.assertEqual(gen_numbers, [])
+
+        # The first item of each chunk should be generated on chunk generation
         first_chunk = next(all_chunks)
-        self.assertEqual(len(first_chunk._cache), 0)
+        self.assertEqual(gen_numbers, [0])
 
         # If we don't read a chunk before getting its successor, its contents
         # will be cached
         second_chunk = next(all_chunks)
-        self.assertEqual(len(first_chunk._cache), 4)
+        self.assertEqual(gen_numbers, [0, 1, 2, 3, 4])
 
-        # If we read in order, there again should be nothing cached
-        mi.consume(first_chunk)
-        mi.consume(second_chunk)
+        # Check if we can read in cached values
+        self.assertEqual(list(first_chunk), [0, 1, 2, 3])
+        self.assertEqual(list(second_chunk), [4, 5, 6, 7])
+
+        # Again only the most recent chunk should have an item cached
         third_chunk = next(all_chunks)
-        for chunk in (first_chunk, second_chunk, third_chunk):
-            self.assertEqual(len(chunk._cache), 0)
+        self.assertEqual(len(gen_numbers), 9)
+
+        # No new item should be cached when reading past the first number
+        next(third_chunk)
+        self.assertEqual(len(gen_numbers), 9)
+
+        # we should not be able to read spent chunks
+        self.assertEqual(list(first_chunk), [])
+        self.assertEqual(list(second_chunk), [])
 
 
 class DistinctCombinationsTests(TestCase):


### PR DESCRIPTION
### Issue reference

https://github.com/more-itertools/more-itertools/issues/797

### Changes
I was trying to create my own `ichunked` method and found this library and thought I might contribute. This new method implementation runs about 2x faster than the current implementation due to it not using any user created iterators (eg. classes with the `next()` method).

There should be no changes visible to the end user other than the speed difference unless the user is relying on the private class `_IChunk`.

This implementation uses a scoped variables within a wrapping method scope to modify the state of the generator on the fly.

I have tested and timed this method extensively using both calls to `next()` and just looping. I have also tried modifying the state part way through iteration and I have not run across any issues.

A simple timing test:

- Before
![image](https://github.com/more-itertools/more-itertools/assets/22060392/908730eb-ce57-4070-b0de-bb58bf7b6f29)
- After
![image](https://github.com/more-itertools/more-itertools/assets/22060392/848cac2a-699a-4858-98d7-631bf48b720a)