### PR TITLE
Minor improvement for `padded`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1536,8 +1536,9 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
             item_count += 1
 
         remaining = (n - item_count) % n if next_multiple else n - item_count
-        for _ in range(remaining):
-            yield fillvalue
+
+        if remaining > 0:
+            yield from repeat(fillvalue, remaining)
 
 
 def repeat_each(iterable, n=2):


### PR DESCRIPTION
### Issue reference

https://github.com/more-itertools/more-itertools/issues/798

### Changes

A small speed improvement for the `padded` method by using `yield from` rather than a loop.

Before:
![image](https://github.com/more-itertools/more-itertools/assets/22060392/b7e46091-415e-4226-adcf-9dabbd46fcb7)

After:
![image](https://github.com/more-itertools/more-itertools/assets/22060392/bdbb99ed-c0c1-4a9b-8178-6f1e63cf0071)

### Checks and tests
Not sure how to do this but will do as soon as I can figure it out.
