### PR TITLE
Remove recursion from `collapse`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1191,7 +1191,7 @@ def collapse(iterable, base_type=None, levels=None):
     while stack:
         node_group = stack.popleft()
         level, nodes = node_group
-        
+
         # Check if beyond max level
         if levels is not None and level > levels:
             yield from nodes
@@ -1199,7 +1199,9 @@ def collapse(iterable, base_type=None, levels=None):
 
         for node in nodes:
             # Check if done iterating
-            if (isinstance(node, (str, bytes)) or ((base_type is not None) and isinstance(node, base_type))):
+            if isinstance(node, (str, bytes)) or (
+                (base_type is not None) and isinstance(node, base_type)
+            ):
                 yield node
             # Otherwise try to create child nodes
             else:
@@ -1214,7 +1216,7 @@ def collapse(iterable, base_type=None, levels=None):
                     stack.appendleft((level + 1, tree))
                     # Break to process child node
                     break
-        
+
 
 def side_effect(func, iterable, chunk_size=None, before=None, after=None):
     """Invoke *func* on each item in *iterable* (or on each *chunk_size* group

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1199,10 +1199,7 @@ def collapse(iterable, base_type=None, levels=None):
 
         for node in nodes:
             # Check if done iterating
-            if (
-                isinstance(node, (str, bytes))
-                or ((base_type is not None) and isinstance(node, base_type))
-            ):
+            if (isinstance(node, (str, bytes)) or ((base_type is not None) and isinstance(node, base_type))):
                 yield node
             # Otherwise try to create child nodes
             else:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1186,7 +1186,7 @@ def collapse(iterable, base_type=None, levels=None):
     """
     stack = deque()
     # Add our first node group, treat the iterable as a single node
-    stack.append((0, repeat(iterable, 1)))
+    stack.appendleft((0, repeat(iterable, 1)))
 
     while stack:
         node_group = stack.popleft()

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1184,15 +1184,15 @@ def collapse(iterable, base_type=None, levels=None):
     ['a', ['b'], 'c', ['d']]
 
     """
-    node_groups = deque()
+    stack = deque()
     # Add our first node group, treat the iterable as a single node
-    node_groups.append((0, repeat(iterable, 1)))
+    stack.append((0, repeat(iterable, 1)))
 
-    while node_groups:
-        node_group = node_groups.popleft()
+    while stack:
+        node_group = stack.popleft()
         level, nodes = node_group
         
-        # Check if beyond
+        # Check if beyond max level
         if levels is not None and level > levels:
             yield from nodes
             continue
@@ -1212,9 +1212,9 @@ def collapse(iterable, base_type=None, levels=None):
                     yield node
                 else:
                     # Save our current location
-                    node_groups.appendleft(node_group)
+                    stack.appendleft(node_group)
                     # Append the new child node
-                    node_groups.appendleft((level + 1, tree))
+                    stack.appendleft((level + 1, tree))
                     # Break to process child node
                     break
         


### PR DESCRIPTION
### Issue reference

https://github.com/more-itertools/more-itertools/issues/799

### Changes

Change collapse to remove the recursion resulting in noticeable speedup.

Before:
![image](https://github.com/more-itertools/more-itertools/assets/22060392/67ee58e1-d707-49fa-91c0-2af306e981d5)
After:
![image](https://github.com/more-itertools/more-itertools/assets/22060392/67f1523e-d13f-4e94-902c-3affb785b9b2)