### PR TITLE
add bucket.as_dict

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1018,6 +1018,9 @@ class bucket:
 
         return self._get_values(value)
 
+    def as_dict(self):
+        return {key: self[key] for key in self}
+
 
 def spy(iterable, n=1):
     """Return a 2-tuple with a list containing the first *n* elements of

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -940,6 +940,14 @@ class BucketTests(TestCase):
         self.assertEqual(list(D[20]), [])
         self.assertEqual(list(D[30]), [30, 31, 33])
 
+    def test_as_dict(self):
+        iterable = [10, 20, 30, 11, 21, 31, 12, 22, 23, 33]
+        key = lambda x: 10 * (x // 10)
+        D = mi.bucket(iterable, key)
+        as_dict = D.as_dict()
+        self.assertFalse(isinstance(as_dict[10], tuple)) # Should be generator
+        self.assertEqual(tuple(as_dict[10]), (10,11,12))
+
 
 class SpyTests(TestCase):
     """Tests for ``spy()``"""

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -945,8 +945,8 @@ class BucketTests(TestCase):
         key = lambda x: 10 * (x // 10)
         D = mi.bucket(iterable, key)
         as_dict = D.as_dict()
-        self.assertFalse(isinstance(as_dict[10], tuple)) # Should be generator
-        self.assertEqual(tuple(as_dict[10]), (10,11,12))
+        self.assertFalse(isinstance(as_dict[10], tuple))  # Should be generator
+        self.assertEqual(tuple(as_dict[10]), (10, 11, 12))
 
 
 class SpyTests(TestCase):


### PR DESCRIPTION
fixes: https://github.com/more-itertools/more-itertools/issues/800

### Changes
- Adds the `bucket.as_dict()` method, returning a dictionary of the form {key: generator}

### Checks and tests
- Unit test
