### PR TITLE
Closes #780: add pre/postpend examples in value_chain doc

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3956,6 +3956,11 @@ def value_chain(*args):
         >>> list(value_chain('12', '34', ['56', '78']))
         ['12', '34', '56', '78']
 
+    Pre- or postpend a single element to an iterable: 
+        >>> list(value_chain(1, [2, 3, 4, 5, 6]))
+        [1, 2, 3, 4, 5, 6]
+        >>> list(value_chain([1, 2, 3, 4, 5], 6))
+        [1, 2, 3, 4, 5, 6]
 
     Multiple levels of nesting are not flattened.
 


### PR DESCRIPTION
### Issue reference
#780 

### Changes
Add explicit "prepend" and "postpend" examples to the docstring for value_chain

### Checks and tests
<!-- Please run `make all-checks` to help make sure your branch meets the standards enforced by GitHub Actions. -->
