### PR TITLE
Add new tool `make_size`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4679,7 +4679,6 @@ def make_size(iterable, n, fillvalue=None):
 
     *n* must be >= 0
     """
-
     iterable = iter(iterable)
     if n < 0:
         raise ValueError('n must be >= 0')

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -91,6 +91,7 @@ __all__ = [
     'longest_common_prefix',
     'lstrip',
     'make_decorator',
+    'make_size',
     'map_except',
     'map_if',
     'map_reduce',
@@ -4664,3 +4665,23 @@ def filter_map(func, iterable):
         y = func(x)
         if y is not None:
             yield y
+
+
+def make_size(iterable, n, fillvalue=None):
+    """Yield the elements from *iterable*, followed by *fillvalue*, such that
+    exactly *n* items are emitted.
+
+        >>> list(make_size([1, 2, 3], 5))
+        [1, 2, 3, None, None]
+
+        >>> list(make_size([1, 2, 3], 5, fillvalue=0))
+        [1, 2, 3, 0, 0]
+
+    *n* must be >= 0
+    """
+
+    iterable = iter(iterable)
+    if n < 0:
+        raise ValueError('n must be >= 0')
+
+    return islice(chain(iterable, repeat(fillvalue)), n)

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -693,3 +693,14 @@ def filter_map(
     func: Callable[[_T], _V | None],
     iterable: Iterable[_T],
 ) -> Iterator[_V]: ...
+@overload
+def make_size(
+    iterable: Iterable[_T],
+    n: int,
+) -> Iterator[_T | None]: ...
+@overload
+def make_size(
+    iterable: Iterable[_T],
+    n: int,
+    fillvalue: _U,
+) -> Iterator[_T | _U]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5742,3 +5742,59 @@ class FilterMapTests(TestCase):
         )
         expected = [1, 2, 3]
         self.assertEqual(actual, expected)
+
+
+class MakeSizeTests(TestCase):
+    def test_errors(self):
+        with self.assertRaises(ValueError):
+            mi.make_size([], -1)
+        with self.assertRaises(TypeError):
+            mi.make_size(None, 1)
+
+    def test_empty(self):
+        seq = []
+
+        self.assertEqual(
+            list(mi.make_size(seq, 6)),
+            [None, None, None, None, None, None],
+        )
+        self.assertEqual(
+            list(mi.make_size(seq, 6, fillvalue=0)),
+            [0, 0, 0, 0, 0, 0],
+        )
+
+    def test_too_short(self):
+        seq = [1, 2, 3, 4]
+
+        self.assertEqual(
+            list(mi.make_size(seq, 6)),
+            [1, 2, 3, 4, None, None],
+        )
+        self.assertEqual(
+            list(mi.make_size(seq, 6, fillvalue=0)),
+            [1, 2, 3, 4, 0, 0],
+        )
+
+    def test_exact_size(self):
+        seq = [1, 2, 3, 4, 5, 6]
+
+        self.assertEqual(
+            list(mi.make_size(seq, 6)),
+            [1, 2, 3, 4, 5, 6],
+        )
+        self.assertEqual(
+            list(mi.make_size(seq, 6, fillvalue=0)),
+            [1, 2, 3, 4, 5, 6],
+        )
+
+    def test_too_long(self):
+        seq = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        self.assertEqual(
+            list(mi.make_size(seq, 6)),
+            [1, 2, 3, 4, 5, 6],
+        )
+        self.assertEqual(
+            list(mi.make_size(seq, 6, fillvalue=0)),
+            [1, 2, 3, 4, 5, 6],
+        )


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#794

### Changes
Yield the elements from an iterable followed by a fillvalue, such that exactly n items are emitted.
