### PR TITLE
Add exactly size of n doc to padded

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1536,7 +1536,7 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
     If *n* is ``None``, *fillvalue* will be emitted indefinitely.
 
     To create an *iterable* of exactly *n* size you can compose native
-    itertool methods:
+    itertools methods:
 
         >>> list(islice(chain([1, 2, 3], repeat('?')), 5))
         [1, 2, 3, '?', '?']

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1528,7 +1528,7 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
         [1, 2, 3, '?', '?']
 
     If *next_multiple* is ``True``, *fillvalue* will be emitted until the
-    number of items emitted is a multiple of *n*::
+    number of items emitted is a multiple of *n*:
 
         >>> list(padded([1, 2, 3, 4], n=3, next_multiple=True))
         [1, 2, 3, 4, None, None]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1535,6 +1535,14 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
 
     If *n* is ``None``, *fillvalue* will be emitted indefinitely.
 
+    To create an *iterable* of exactly *n* size you can compose native
+    itertool methods:
+
+        >>> list(islice(chain([1, 2, 3], repeat('?')), 5))
+        [1, 2, 3, '?', '?']
+        >>> list(islice(chain([1, 2, 3, 4, 5, 6, 7, 8], repeat('?')), 5))
+        [1, 2, 3, 4, 5]
+
     """
     iterable = iter(iterable)
     iterable_with_repeat = chain(iterable, repeat(fillvalue))

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1535,8 +1535,7 @@ def padded(iterable, fillvalue=None, n=None, next_multiple=False):
 
     If *n* is ``None``, *fillvalue* will be emitted indefinitely.
 
-    To create an *iterable* of exactly *n* size you can compose native
-    itertools methods:
+    To create an *iterable* of exactly *n* size you can compose native itertools methods:
 
         >>> list(islice(chain([1, 2, 3], repeat('?')), 5))
         [1, 2, 3, '?', '?']


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#794

### Changes
I have used to native method I discussed in the issue to add to the documentation. If this is not acceptable and we want to only compose using the `padded` method I don't think any docstring PR should be merged related to this issue.

Using the padded method
`islice(padded(iterable, '?', n), n)`
is less performant and less clear than using
`islice(chain(iterable, repeat('?')), n)`
in my opinion.

Thoughts on this are welcome.
