### PR TITLE
Update table of contents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ source_suffix = '.rst'
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = 'toctree'
 
 # General information about the project.
 project = 'more-itertools'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,1 @@
 .. include:: ./_build/README.pprst
-
-Contents
-========
-
-.. toctree::
-    :maxdepth: 2
-
-    api
-
-.. toctree::
-    :maxdepth: 1
-
-    license
-    testing
-    versions

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -1,0 +1,15 @@
+Contents
+========
+
+.. toctree::
+    :maxdepth: 2
+
+    index
+    api
+
+.. toctree::
+    :maxdepth: 1
+
+    license
+    testing
+    versions


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#639

### Changes
- Move the `toctree `directive from `docs/index.rst` to `docs/toctree.rst`
- Add a reference to `index `to the table of contents in that new file
- Update `docs/conf.py` to point `master_doc` to the new file
As detailed in the [Issue discussion](https://github.com/more-itertools/more-itertools/issues/639#issuecomment-1216995526)

