### PR TITLE
Optimize adjacent itertool

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1955,7 +1955,7 @@ def adjacent(predicate, iterable, distance=1):
     drawn from *iterable* and the `bool` indicates whether
     that item satisfies the *predicate* or is adjacent to an item that does.
 
-    For example, to find whether items are adjacent to a ``3``::
+    For example, to find whether items are adjacent to a ``3``:
 
         >>> list(adjacent(lambda x: x == 3, range(6)))
         [(False, 0), (False, 1), (True, 2), (True, 3), (True, 4), (False, 5)]

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1983,11 +1983,11 @@ def adjacent(predicate, iterable, distance=1):
     if distance < 0:
         raise ValueError('distance must be at least 0')
 
-    # split the iterable into two
+    # Split the iterable into two
     items, lookahead = tee(iterable)
 
     # Create an adjacency score that will keep track of the
-    # last value that had a True predicate via a count
+    # last value that had a true predicate via a count
     bad_adj_score = -(distance + 1)
     adj_scores = accumulate(
         chain(map(predicate, lookahead), repeat(False)),


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#811

### Changes
Increases the performance of the adjacent itertool by using a counting method to check for adjacency.

Check the issue for performance overview.
