### PR TITLE
Optimize replace itertool

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3093,7 +3093,9 @@ def rlocate(iterable, pred=bool, window_size=None):
     return reversed(list(locate(iterable, pred, window_size)))
 
 
-def replace(iterable, pred, substitutes, count=None, window_size=1):
+def replace(
+    iterable, pred, substitutes, count=None, window_size=1, default_arg=_marker
+):
     """Yield the items from *iterable*, replacing the items for which *pred*
     returns ``True`` with the items from the iterable *substitutes*.
 
@@ -3121,6 +3123,20 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
         >>> list(replace(iterable, pred, substitutes, window_size=window_size))
         [3, 4, 5, 3, 4, 5]
 
+    Use *default_arg* to specify the default value passed as arguments to
+    *pred* when at the end of the iterable.
+    This option is only used when *window_size* is greater than 1.
+
+        >>> list(replace(
+        ...     [1, 0, 0, 5, 0, 1, 1],
+        ...     # 3 items passed to pred with default of 0
+        ...     lambda *args: args == (1, 0, 0),
+        ...     [3, 4], # Splice in these items
+        ...     window_size=3,
+        ...     default_arg=0,
+        ... ))
+        [3, 4, 5, 0, 1, 3, 4]
+
     """
     if window_size < 1:
         raise ValueError('window_size must be at least 1')
@@ -3130,7 +3146,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
 
     # Create the iterable with padding so we don't run out of elements
     # to pass to the predicate
-    iterable = chain(iter(iterable), (_marker,) * (window_size - 1))
+    iterable = chain(iter(iterable), (default_arg,) * (window_size - 1))
 
     # Create an almost full window
     window = deque(islice(iterable, window_size - 1), maxlen=window_size)

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -495,6 +495,7 @@ def replace(
     substitutes: Iterable[_U],
     count: int | None = ...,
     window_size: int = ...,
+    default_arg: _V = ...,
 ) -> Iterator[_T | _U]: ...
 def partitions(iterable: Iterable[_T]) -> Iterator[list[list[_T]]]: ...
 def set_partitions(

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3693,6 +3693,18 @@ class ReplaceTests(TestCase):
         with self.assertRaises(ValueError):
             list(mi.replace(iterable, pred, substitutes, window_size=0))
 
+    def test_default_arg(self):
+        iterable = range(10)
+        pred = lambda *args: args[-1] == 0
+        substitutes = []
+        actual = list(
+            mi.replace(
+                iterable, pred, substitutes, window_size=3, default_arg=0
+            )
+        )
+        expected = [0, 1, 2, 3, 4, 5, 6, 7]
+        self.assertEqual(actual, expected)
+
     def test_iterable_substitutes(self):
         iterable = range(5)
         pred = lambda x: x % 2 == 0


### PR DESCRIPTION
### Issue reference

more-itertools/more-itertools#813

### Changes

Increases the performance of the `replace` itertool by removing the reliance on `windowed` as well as other minor adjustments.

Check the issue for performance overview.

I have also added the `default_arg` option to specify what default arguments are passed to the `pred` when reaching the end of the iterable. I'm not sure using `_marker` was ever good practice but I have left the default as `_marker` for backwards compatibility. We should probably think about changing this in the future however.
