### PR TITLE
Optimize unique_in_window itertool

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4307,7 +4307,7 @@ def unique_in_window(iterable, n, key=None):
 
         >>> iterable = [0, 1, 0, 2, 3, 0]
         >>> n = 3
-        >>> list(unique_in_window([0, 1, 0, 2, 3, 0], 3))
+        >>> list(unique_in_window(iterable, n))
         [0, 1, 2, 3, 0]
 
     The *key* function, if provided, will be used to determine uniqueness:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4322,10 +4322,9 @@ def unique_in_window(iterable, n, key=None):
         raise ValueError('n must be greater than 0')
 
     iterable = iter(iterable)
-
     key_exists = key is not None
-
     buffer = OrderedDict()
+
     for idx, item in enumerate(iterable):
         k = key(item) if key_exists else item
 
@@ -4335,19 +4334,17 @@ def unique_in_window(iterable, n, key=None):
             if idx - buffer[k] >= n:
                 yield item
 
-            # Update the index and move the key forward so it doesn't
-            # fall off the queue
-            buffer[k] = idx
+            # Move the key forward so it doesn't fall off the queue
             buffer.move_to_end(k)
-
         # The item isn't in the buffer e.g. we haven't see it
         else:
             yield item
-            if n > 1:
-                # Replace old item in the buffer with new
-                if len(buffer) >= n:
-                    buffer.popitem(False)
-                buffer[k] = idx
+            # Replace old item in the buffer with new
+            if len(buffer) >= n:
+                buffer.popitem(False)
+
+        # Update the key index
+        buffer[k] = idx
 
 
 def duplicates_everseen(iterable, key=None):


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#817

### Changes
Optimize the performance of the unique_in_window itertool by using collections.OrderedDict to keep track of the last items we've seen. This increases performance by ~30%.

See the linked issue for performance overview.
