### PR TITLE
Issue 822: update iter_index docs

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -828,8 +828,6 @@ def iter_index(iterable, value, start=0, stop=None):
     """Yield the index of each place in *iterable* that *value* occurs,
     beginning with index *start* and ending before index *stop*.
 
-    See :func:`locate` for a more general means of finding the indexes
-    associated with particular values.
 
     >>> list(iter_index('AABCADEAF', 'A'))
     [0, 1, 4, 7]
@@ -837,6 +835,19 @@ def iter_index(iterable, value, start=0, stop=None):
     [1, 4, 7]
     >>> list(iter_index('AABCADEAF', 'A', 1, 7))  # stop index is not inclusive
     [1, 4]
+
+    The behavior for non-scalar *values* matches the built-in Python types.
+
+    >>> list(iter_index('ABCDABCD', 'AB'))
+    [0, 4]
+    >>> list(iter_index([0, 1, 2, 3, 0, 1, 2, 3], [0, 1]))
+    []
+    >>> list(iter_index([[0, 1], [2, 3], [0, 1], [2, 3]], [0, 1]))
+    [0, 2]
+
+    See :func:`locate` for a more general means of finding the indexes
+    associated with particular values.
+
     """
     seq_index = getattr(iterable, 'index', None)
     if seq_index is None:


### PR DESCRIPTION
This PR adds examples of using `iter_index` with non-scalar values.

Closes #822.