### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import more_itertools
 # to readthedocs.io for display on github.com, but those links can be
 # relative when being built for Sphinx.
 
-with open('../README.rst', 'rt') as source:
+with open('../README.rst') as source:
     readme_file = source.readlines()
 
 build_dir = '_build'
@@ -35,7 +35,7 @@ os.makedirs(build_dir, exist_ok=True)
 rtd_path = 'https://more-itertools.readthedocs.io/en/stable/'
 table_width = 200
 in_table = False
-with open(os.path.join('.', build_dir, 'README.pprst'), 'wt') as target:
+with open(os.path.join('.', build_dir, 'README.pprst'), 'w') as target:
     for line in readme_file:
         old_len = len(line)
         if line.startswith('|') and line.endswith('|\n'):  # Inside table

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -633,13 +633,13 @@ def strictly_n(iterable, n, too_short=None, too_long=None):
     if too_short is None:
         too_short = lambda item_count: raise_(
             ValueError,
-            'Too few items in iterable (got {})'.format(item_count),
+            f'Too few items in iterable (got {item_count})',
         )
 
     if too_long is None:
         too_long = lambda item_count: raise_(
             ValueError,
-            'Too many items in iterable (got at least {})'.format(item_count),
+            f'Too many items in iterable (got at least {item_count})',
         )
 
     it = iter(iterable)
@@ -2253,7 +2253,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
                 if r == self._zero:
                     return int(q)
 
-        raise ValueError("{} is not in numeric range".format(value))
+        raise ValueError(f"{value} is not in numeric range")
 
     def _get_by_index(self, i):
         if i < 0:
@@ -2727,7 +2727,7 @@ class SequenceView(Sequence):
         return len(self._target)
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, repr(self._target))
+        return f'{self.__class__.__name__}({repr(self._target)})'
 
 
 class seekable:


### PR DESCRIPTION
Filter all code over `pyupgrade --py38-plus`.
