### PR TITLE
Issue 854: sample improvements

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4,7 +4,7 @@ import warnings
 from collections import Counter, defaultdict, deque, abc
 from collections.abc import Sequence
 from functools import cached_property, partial, reduce, wraps
-from heapq import heapify, heapreplace, heappop
+from heapq import heapify, heapreplace
 from itertools import (
     chain,
     combinations,

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3597,8 +3597,7 @@ def _sample_weighted(iterator, k, weights, strict):
         else:
             weights_to_skip -= weight
 
-    # Equivalent to [element for weight_key, element i n sorted(reservoir)]
-    ret = [heappop(reservoir)[1] for _ in range(k)]
+    ret = [element for weight_key, element in reservoir]
     shuffle(ret)
     return ret
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -23,7 +23,7 @@ from itertools import (
 )
 from math import comb, e, exp, factorial, floor, fsum, log, perm, tau
 from queue import Empty, Queue
-from random import random, randrange, uniform
+from random import random, randrange, shuffle, uniform
 from operator import itemgetter, mul, sub, gt, lt, ge, le
 from sys import hexversion, maxsize
 from time import monotonic
@@ -3557,6 +3557,7 @@ def _sample_unweighted(iterable, k):
             W *= exp(log(random()) / k)
             next_index += floor(log(random()) / log(1 - W)) + 1
 
+    shuffle(reservoir)
     return reservoir
 
 
@@ -3592,19 +3593,21 @@ def _sample_weighted(iterable, k, weights):
             weights_to_skip -= weight
 
     # Equivalent to [element for weight_key, element in sorted(reservoir)]
+    shuffle(reservoir)
     return [heappop(reservoir)[1] for _ in range(k)]
 
 
 def sample(iterable, k, weights=None):
     """Return a *k*-length list of elements chosen (without replacement)
-    from the *iterable*. Like :func:`random.sample`, but works on iterables
-    of unknown length.
+    from the *iterable*. Similar to :func:`random.sample`, but works on
+    iterables of unknown length.
 
     >>> iterable = range(100)
     >>> sample(iterable, 5)  # doctest: +SKIP
     [81, 60, 96, 16, 4]
 
-    An iterable with *weights* may also be given:
+    An iterable with *weights* may also be given (this is not analagous to
+    :func:`random.sample`'s  ``counts`` parameter):
 
     >>> iterable = range(100)
     >>> weights = (i * i + 1 for i in range(100))
@@ -3619,7 +3622,12 @@ def sample(iterable, k, weights=None):
     >>> weights = range(1, len(data) + 1)
     >>> sample(data, k=len(data), weights=weights)  # doctest: +SKIP
     ['c', 'a', 'b', 'e', 'g', 'd', 'h', 'f']
+
+    If the length of *iterable* is less than *k*, all elements will be
+    returned.
     """
+    if k < 0:
+        raise ValueError('k must be non-negative')
     if k == 0:
         return []
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3597,9 +3597,10 @@ def _sample_weighted(iterator, k, weights, strict):
         else:
             weights_to_skip -= weight
 
-    # Equivalent to [element for weight_key, element in sorted(reservoir)]
-    shuffle(reservoir)
-    return [heappop(reservoir)[1] for _ in range(k)]
+    # Equivalent to [element for weight_key, element i n sorted(reservoir)]
+    ret = [heappop(reservoir)[1] for _ in range(k)]
+    shuffle(ret)
+    return ret
 
 
 def sample(iterable, k, weights=None, strict=False):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3611,26 +3611,26 @@ def sample(iterable, k, weights=None, strict=False):
     >>> sample(iterable, 5)  # doctest: +SKIP
     [81, 60, 96, 16, 4]
 
-    An iterable with *weights* may also be given (this is not analagous to
-    :func:`random.sample`'s  ``counts`` parameter):
+    An iterable with *weights* may also be given:
 
     >>> iterable = range(100)
     >>> weights = (i * i + 1 for i in range(100))
     >>> sampled = sample(iterable, 5, weights=weights)  # doctest: +SKIP
     [79, 67, 74, 66, 78]
 
-    The algorithm can also be used to generate weighted random permutations.
-    The relative weight of each item determines the probability that it
-    appears late in the permutation.
+    Weighted selections are made without replacement.
+    After an element is selected, it is removed from the pool and the
+    relative weights of the other elements increase (this
+    does not match the behavior of :func:`random.sample`'s *counts*
+    parameter).
 
-    >>> data = "abcdefgh"
-    >>> weights = range(1, len(data) + 1)
-    >>> sample(data, k=len(data), weights=weights)  # doctest: +SKIP
-    ['c', 'a', 'b', 'e', 'g', 'd', 'h', 'f']
+    If the length of *iterable* is less than *k*,
+    ``ValueError`` is raised if *strict* is ``True`` and
+    all elements are returned (in shuffled order) if *strict* is ``False``.
 
-    If the length of *iterable* is less than *k*:
-    * ``ValueError`` is raised if *strict* is ``True``
-    * All elements arereturned (in shuffled order) if *strict* is ``False``
+    By default, the `Algorithm L <https://w.wiki/ANrM>`__ reservoir sampling
+    technique is used. When *weights* are provided,
+    `Algorithm A-ExpJ <https://w.wiki/ANrS>`__ is used.
     """
     if k < 0:
         raise ValueError('k must be non-negative')

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3535,12 +3535,12 @@ def map_if(iterable, pred, func, func_else=lambda x: x):
         yield func(item) if pred(item) else func_else(item)
 
 
-def _sample_unweighted(it, k, strict):
+def _sample_unweighted(iterator, k, strict):
     # Implementation of "Algorithm L" from the 1994 paper by Kim-Hung Li:
     # "Reservoir-Sampling Algorithms of Time Complexity O(n(1+log(N/n)))".
 
     # Fill up the reservoir (collection of samples) with the first `k` samples
-    reservoir = take(k, it)
+    reservoir = take(k, iterator)
     if strict and len(reservoir) < k:
         raise ValueError('Sample larger than population')
 
@@ -3552,7 +3552,7 @@ def _sample_unweighted(it, k, strict):
     # number with a geometric distribution. Sample it using random() and logs.
     next_index = k + floor(log(random()) / log(1 - W))
 
-    for index, element in enumerate(it, k):
+    for index, element in enumerate(iterator, k):
         if index == next_index:
             reservoir[randrange(k)] = element
             # The new W is the largest in a sample of k U(0, `old_W`) numbers
@@ -3563,7 +3563,7 @@ def _sample_unweighted(it, k, strict):
     return reservoir
 
 
-def _sample_weighted(it, k, weights, strict):
+def _sample_weighted(iterator, k, weights, strict):
     # Implementation of "A-ExpJ" from the 2006 paper by Efraimidis et al. :
     # "Weighted random sampling with a reservoir".
 
@@ -3572,7 +3572,7 @@ def _sample_weighted(it, k, weights, strict):
 
     # Fill up the reservoir (collection of samples) with the first `k`
     # weight-keys and elements, then heapify the list.
-    reservoir = take(k, zip(weight_keys, it))
+    reservoir = take(k, zip(weight_keys, iterator))
     if strict and len(reservoir) < k:
         raise ValueError('Sample larger than population')
 
@@ -3583,7 +3583,7 @@ def _sample_weighted(it, k, weights, strict):
     smallest_weight_key, _ = reservoir[0]
     weights_to_skip = log(random()) / smallest_weight_key
 
-    for weight, element in zip(weights, it):
+    for weight, element in zip(weights, iterator):
         if weight >= weights_to_skip:
             # The notation here is consistent with the paper, but we store
             # the weight-keys in log-space for better numerical stability.
@@ -3637,12 +3637,12 @@ def sample(iterable, k, weights=None, strict=False):
     if k == 0:
         return []
 
-    iterable = iter(iterable)
+    iterator = iter(iterable)
     if weights is None:
-        return _sample_unweighted(iterable, k, strict)
+        return _sample_unweighted(iterator, k, strict)
     else:
         weights = iter(weights)
-        return _sample_weighted(iterable, k, weights, strict)
+        return _sample_weighted(iterator, k, weights, strict)
 
 
 def is_sorted(iterable, key=None, reverse=False, strict=False):

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -542,6 +542,7 @@ def sample(
     iterable: Iterable[_T],
     k: int,
     weights: Iterable[float] | None = ...,
+    strict: bool = ...,
 ) -> list[_T]: ...
 def is_sorted(
     iterable: Iterable[_T],

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -538,11 +538,15 @@ def map_if(
     func: Callable[[Any], Any],
     func_else: Callable[[Any], Any] | None = ...,
 ) -> Iterator[Any]: ...
+def _sample_unweighted(iterator: Iterator[_T], k: int, strict) -> list[_T]: ...
+def _sample_weighted(
+    iterator: Iterator[_T], k: int, weights, strict
+) -> list[_T]: ...
 def sample(
     iterable: Iterable[_T],
     k: int,
     weights: Iterable[float] | None = ...,
-    strict: bool = ...,
+    strict: bool = False,
 ) -> list[_T]: ...
 def is_sorted(
     iterable: Iterable[_T],

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4145,6 +4145,11 @@ class SampleTests(TestCase):
         expected = ['f', 'e']
         self.assertEqual(actual, expected)
 
+    def test_negative(self):
+        data = [1, 2, 3, 4, 5]
+        with self.assertRaises(ValueError):
+            mi.sample(data, k=-1)
+
     def test_length(self):
         """Check that *k* elements are sampled."""
         data = [1, 2, 3, 4, 5]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4159,6 +4159,12 @@ class SampleTests(TestCase):
             expected = min(k, len(data))
             self.assertEqual(actual, expected)
 
+    def test_strict(self):
+        data = ['1', '2', '3', '4', '5']
+        self.assertEqual(set(mi.sample(data, 6, strict=False)), set(data))
+        with self.assertRaises(ValueError):
+            mi.sample(data, 6, strict=True)
+
     def test_sampling_entire_iterable(self):
         """If k=len(iterable), the sample contains the original elements."""
         data = ["a", 2, "a", 4, (1, 2, 3)]


### PR DESCRIPTION
This PR makes some changes to sample:
* `shuffle` is called before returning the output
* A note about differences from `random.sample` is added to the docstring
* `ValueError` is raised for negative `k` values

Closes #854