### PR TITLE
Issue 858: Use chain and starmap in run_length.decode

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2903,7 +2903,7 @@ class run_length:
 
     @staticmethod
     def decode(iterable):
-        return chain.from_iterable(repeat(k, n) for k, n in iterable)
+        return chain.from_iterable(starmap(repeat, iterable))
 
 
 def exactly_n(iterable, n, predicate=bool):


### PR DESCRIPTION
This PR updates `run_length.decode` to use `starmap` per [the issue](https://github.com/more-itertools/more-itertools/issues/858).

Thanks to @rhettinger for the suggestion!

Closes #858