### PR TITLE
Issue 862: change relative_seek() behaviour

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2823,9 +2823,9 @@ class seekable:
         >>> it.relative_seek(-3)  # Source is at '6', we move back to '3'
         >>> next(it)
         '3'
-        >>> it.relative_seek(-3)  # Source is still at '6', we move back to '3'
+        >>> it.relative_seek(-3)  # Source is at '3', we move back to '1'
         >>> next(it)
-        '3'
+        '1'
 
 
     Call :meth:`peek` to look ahead one item without advancing the iterator:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2823,7 +2823,7 @@ class seekable:
         >>> it.relative_seek(-3)  # Source is at '6', we move back to '3'
         >>> next(it)
         '3'
-        >>> it.relative_seek(-3)  # Source is at '3', we move back to '1'
+        >>> it.relative_seek(-3)  # Source is at '4', we move back to '1'
         >>> next(it)
         '1'
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2935,8 +2935,10 @@ class seekable:
             consume(self, remainder)
 
     def relative_seek(self, count):
-        index = len(self._cache)
-        self.seek(max(index + count, 0))
+        if self._index is None:
+            self._index = len(self._cache)
+
+        self.seek(max(self._index + count, 0))
 
 
 class run_length:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3349,7 +3349,9 @@ class SeekableTest(PeekableMixinTests, TestCase):
         s.relative_seek(-2)
         self.assertEqual(next(s), '1')
         s.relative_seek(-2)
-        self.assertEqual(next(s), '0')    # Seek relative to current position within the cache
+        self.assertEqual(
+            next(s), '0'
+        )  # Seek relative to current position within the cache
         s.relative_seek(-10)  # Lower bound
         self.assertEqual(next(s), '0')
         s.relative_seek(10)  # Lower bound

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3348,6 +3348,8 @@ class SeekableTest(PeekableMixinTests, TestCase):
         self.assertEqual(next(s), '2')
         s.relative_seek(-2)
         self.assertEqual(next(s), '1')
+        s.relative_seek(-2)
+        self.assertEqual(next(s), '0')    # Seek relative to current position within the cache
         s.relative_seek(-10)  # Lower bound
         self.assertEqual(next(s), '0')
         s.relative_seek(10)  # Lower bound


### PR DESCRIPTION
### Issue reference
Closes 862

### Changes
Change relative_seek() behaviour to seek relative to current position (possibly within the cache), as opposed to, seeking to the cache head, which had been implemented previously.

### Checks and tests
Passes make all-checks
