### PR TITLE
Issue 876: is_sorted clarifications

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3720,12 +3720,16 @@ def is_sorted(iterable, key=None, reverse=False, strict=False):
     False
 
     The function returns ``False`` after encountering the first out-of-order
-    item. If there are no out-of-order items, the iterable is exhausted.
+    item, which means it may produce results that differ from the built-in
+    :func:`sorted` function for objects with unusual comparison dynamics.
+    If there are no out-of-order items, the iterable is exhausted.
     """
+    compare = le if strict else lt
+    it = iterable if (key is None) else map(key, iterable)
+    it_1, it_2 = tee(it)
+    next(it_2 if reverse else it_1, None)
 
-    compare = (le if reverse else ge) if strict else (lt if reverse else gt)
-    it = iterable if key is None else map(key, iterable)
-    return not any(starmap(compare, pairwise(it)))
+    return not any(map(compare, it_1, it_2))
 
 
 class AbortThread(BaseException):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -25,7 +25,7 @@ from itertools import (
 from math import comb, e, exp, factorial, floor, fsum, log, log1p, perm, tau
 from queue import Empty, Queue
 from random import random, randrange, shuffle, uniform
-from operator import itemgetter, mul, sub, gt, lt, ge, le
+from operator import itemgetter, mul, sub, gt, lt, le
 from sys import hexversion, maxsize
 from time import monotonic
 
@@ -35,7 +35,6 @@ from .recipes import (
     UnequalIterablesError,
     consume,
     flatten,
-    pairwise,
     powerset,
     take,
     unique_everseen,

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4243,6 +4243,7 @@ class IsSortedTests(TestCase):
             ([1, 2, 3], {}, True),
             ([1, 1, 2, 3], {}, True),
             ([1, 10, 2, 3], {}, False),
+            ([3, float('nan'), 1, 2], {}, True),
             (['1', '10', '2', '3'], {}, True),
             (['1', '10', '2', '3'], {'key': int}, False),
             ([1, 2, 3], {'reverse': True}, False),


### PR DESCRIPTION
Re: [Issue 876](https://github.com/more-itertools/more-itertools/issues/876), this PR updates the `is_sorted` implementation to be easier to read (we hope), and to clarify that if you give it objects with contrived sorting dynamics that the results may not match what you imagine.