### PR TITLE
[Docs] Fix strictly_n missing the n parameter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,7 +184,7 @@ These tools yield certain items from an iterable.
 .. autofunction:: last(iterable[, default])
 .. autofunction:: one(iterable, too_short=ValueError, too_long=ValueError)
 .. autofunction:: only(iterable, default=None, too_long=ValueError)
-.. autofunction:: strictly_n(iterable, too_short=None, too_long=None)
+.. autofunction:: strictly_n(iterable, n, too_short=None, too_long=None)
 .. autofunction:: strip
 .. autofunction:: lstrip
 .. autofunction:: rstrip


### PR DESCRIPTION
This very minor fix adds the n parameter to the docs for the `strictly_n` function.