### PR TITLE
Standardize type hints for isinstance's second argument

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys, types
 from types import TracebackType
 from typing import (
     Any,
@@ -34,6 +35,12 @@ _W = TypeVar('_W')
 _T_co = TypeVar('_T_co', covariant=True)
 _GenFn = TypeVar('_GenFn', bound=Callable[..., Iterator[Any]])
 _Raisable = BaseException | Type[BaseException]
+
+# The type of isinstance's second argument (from typeshed builtins)
+if sys.version_info >= (3, 10):
+    _ClassInfo = type | types.UnionType | tuple[_ClassInfo, ...]
+else:
+    _ClassInfo = type | tuple[_ClassInfo, ...]
 
 @type_check_only
 class _SizedIterable(Protocol[_T_co], Sized, Iterable[_T_co]): ...
@@ -135,7 +142,7 @@ def interleave_evenly(
 ) -> Iterator[_T]: ...
 def collapse(
     iterable: Iterable[Any],
-    base_type: type | None = ...,
+    base_type: _ClassInfo | None = ...,
     levels: int | None = ...,
 ) -> Iterator[Any]: ...
 @overload
@@ -290,7 +297,7 @@ def unzip(iterable: Iterable[Sequence[_T]]) -> tuple[Iterator[_T], ...]: ...
 def divide(n: int, iterable: Iterable[_T]) -> list[Iterator[_T]]: ...
 def always_iterable(
     obj: object,
-    base_type: type | tuple[type | tuple[Any, ...], ...] | None = ...,
+    base_type: _ClassInfo | None = ...,
 ) -> Iterator[Any]: ...
 def adjacent(
     predicate: Callable[[_T], bool],
@@ -627,7 +634,7 @@ class countable(Generic[_T], Iterator[_T]):
 def chunked_even(iterable: Iterable[_T], n: int) -> Iterator[list[_T]]: ...
 def zip_broadcast(
     *objects: _T | Iterable[_T],
-    scalar_types: type | tuple[type | tuple[Any, ...], ...] | None = ...,
+    scalar_types: _ClassInfo | None = ...,
     strict: bool = ...,
 ) -> Iterable[tuple[_T, ...]]: ...
 def unique_in_window(


### PR DESCRIPTION
always_iterable, collapse, and zip_broadcast take arguments that are used as the second argument to isinstance.  Before this commit, collapse's type hint was too narrow (rejected tuples of types) and always_iterable/zip_broadcast's type hint was too broad (accepted Any in nested tuples).  All three also omitted UnionType, introduced in Python 3.10, which can also be the second argument of isinstance (provided it does not contain types.GenericAlias).

This commit standardizes these three functions on [typeshed's hint for isinstance](https://github.com/python/typeshed/blob/ea14235f74a0c8c6e58dac06c1d554f6bac74a4e/stdlib/builtins.pyi#L1446).

---

### Issue reference
#885 

### Changes
See the commit message/PR description.

Previously more.pyi used only `from X import Y`.  This commit imports `sys` because [type checkers are allowed to match sys.versioninfo literally](https://typing.readthedocs.io/en/latest/reference/stubs.html#version-and-platform-checks).  This commit also imports `types` because putting `from types import UnionType` inside the version check causes black to add an ugly blank line.

### Checks and tests
`make all-checks` passed.
