### PR TITLE
iequals: defend against unittest.mock.ANY

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -159,6 +159,19 @@ __all__ = [
 _fsumprod = getattr(math, 'sumprod', lambda x, y: fsum(map(mul, x, y)))
 
 
+class _NeverEqual:
+    "A helper object that compares equal to nothing."
+
+    def __eq__(self, other):
+        return False
+
+    def __ne__(self, other):
+        return True
+
+    def __repr__(self):
+        return '<NeverEqual>'
+
+
 def chunked(iterable, n, strict=False):
     """Break *iterable* into lists of length *n*:
 
@@ -3538,7 +3551,9 @@ def iequals(*iterables):
     elements of iterable are equal to each other.
 
     """
-    return all(map(all_equal, zip_longest(*iterables, fillvalue=object())))
+    return all(
+        map(all_equal, zip_longest(*iterables, fillvalue=_NeverEqual()))
+    )
 
 
 def distinct_combinations(iterable, r):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -31,6 +31,7 @@ from sys import version_info
 from time import sleep
 from traceback import format_exc
 from unittest import skipIf, TestCase
+from unittest.mock import ANY
 
 import more_itertools as mi
 
@@ -5519,7 +5520,10 @@ class IequalsTests(TestCase):
         self.assertFalse(mi.iequals([1, 2], [None, 1, 2]))
 
     def test_not_identical_but_equal(self):
-        self.assertTrue([1, True], [1.0, complex(1, 0)])
+        self.assertTrue(mi.iequals([1, True], [1.0, complex(1, 0)]))
+
+    def test_contrived_objects(self):
+        self.assertFalse(mi.iequals([], [ANY]))
 
 
 class ConstrainedBatchesTests(TestCase):


### PR DESCRIPTION
Re: https://github.com/more-itertools/more-itertools/issues/900, this PR changes `iequals` such that it handles objects with exotic `__eq__` behvior.