### PR TITLE
Version 10.5.0

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,6 +5,15 @@ Version History
 .. automodule:: more_itertools
    :noindex:
 
+10.5.0
+------
+
+* Bug fixes
+    * A missing symbol in ``more.pyi`` was fixed (thanks to eberts-google and nathanielmanistaatgoogle)
+
+* Other changes
+    * :func:`all_equal` was optimized (thanks to pochmann3 and rhettinger)
+
 10.4.0
 ------
 

--- a/more_itertools/__init__.py
+++ b/more_itertools/__init__.py
@@ -3,4 +3,4 @@
 from .more import *  # noqa
 from .recipes import *  # noqa
 
-__version__ = '10.4.0'
+__version__ = '10.5.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.4.0
+current_version = 10.5.0
 commit = True
 tag = False
 files = more_itertools/__init__.py


### PR DESCRIPTION
This PR has changes for version 10.5.0. This release is to fix the issue reported in #904 , and also carries along the work on `all_equal` in PR #899.