### PR TITLE
Make polynomial_from_roots() non-recursive

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -13,7 +13,7 @@ import operator
 
 from collections import deque
 from collections.abc import Sized
-from functools import partial, reduce
+from functools import partial
 from itertools import (
     chain,
     combinations,
@@ -872,8 +872,10 @@ def polynomial_from_roots(roots):
     >>> polynomial_from_roots(roots)  # x^3 - 4 * x^2 - 17 * x + 60
     [1, -4, -17, 60]
     """
-    factors = zip(repeat(1), map(operator.neg, roots))
-    return list(reduce(convolve, factors, [1]))
+    poly = [1]
+    for root in roots:
+        poly = list(convolve(poly, (1, -root)))
+    return poly
 
 
 def iter_index(iterable, value, start=0, stop=None):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from functools import reduce
 from itertools import combinations, count, groupby, permutations
 from operator import mul
-from math import factorial
+from math import comb, factorial
 from sys import version_info
 from unittest import TestCase, skipIf
 from unittest.mock import patch
@@ -922,6 +922,12 @@ class PolynomialFromRootsTests(TestCase):
             with self.subTest(roots=roots):
                 actual = mi.polynomial_from_roots(roots)
                 self.assertEqual(actual, expected)
+
+    def test_large(self):
+        n = 1_500
+        actual = mi.polynomial_from_roots([-1] * n)
+        expected = [comb(n, k) for k in range(n + 1)]
+        self.assertEqual(actual, expected)
 
 
 class PolynomialEvalTests(TestCase):


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#912

### Changes
As discussed in issue #912:
- Adds large test that makes the recursive implementation fail with "RecursionError: maximum recursion depth exceeded".
- Replaces the implementation with a non-recursive one that passes the test.