### PR TITLE
Issue 916: lt only for is_sorted

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -25,7 +25,7 @@ from itertools import (
 from math import comb, e, exp, factorial, floor, fsum, log, log1p, perm, tau
 from queue import Empty, Queue
 from random import random, randrange, shuffle, uniform
-from operator import itemgetter, mul, sub, gt, lt, le
+from operator import itemgetter, mul, sub, gt, lt
 from sys import hexversion, maxsize
 from time import monotonic
 
@@ -3819,15 +3819,15 @@ def is_sorted(iterable, key=None, reverse=False, strict=False):
 
     The function returns ``False`` after encountering the first out-of-order
     item, which means it may produce results that differ from the built-in
-    :func:`sorted` function for objects with unusual comparison dynamics.
-    If there are no out-of-order items, the iterable is exhausted.
+    :func:`sorted` function for objects with unusual comparison dynamics
+    (like ``math.nan``). If there are no out-of-order items, the iterable is exhausted.
     """
-    compare = le if strict else lt
     it = iterable if (key is None) else map(key, iterable)
-    it_1, it_2 = tee(it)
-    next(it_2 if reverse else it_1, None)
-
-    return not any(map(compare, it_1, it_2))
+    a, b = tee(it)
+    next(b, None)
+    if reverse:
+        b, a = a, b
+    return all(map(lt, a, b)) if strict else not any(map(lt, b, a))
 
 
 class AbortThread(BaseException):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3820,7 +3820,8 @@ def is_sorted(iterable, key=None, reverse=False, strict=False):
     The function returns ``False`` after encountering the first out-of-order
     item, which means it may produce results that differ from the built-in
     :func:`sorted` function for objects with unusual comparison dynamics
-    (like ``math.nan``). If there are no out-of-order items, the iterable is exhausted.
+    (like ``math.nan``). If there are no out-of-order items, the iterable is
+    exhausted.
     """
     it = iterable if (key is None) else map(key, iterable)
     a, b = tee(it)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4330,7 +4330,6 @@ class IsSortedTests(TestCase):
             ([1, 2, 3], {}, True),
             ([1, 1, 2, 3], {}, True),
             ([1, 10, 2, 3], {}, False),
-            ([3, float('nan'), 1, 2], {}, True),
             (['1', '10', '2', '3'], {}, True),
             (['1', '10', '2', '3'], {'key': int}, False),
             ([1, 2, 3], {'reverse': True}, False),
@@ -4361,17 +4360,6 @@ class IsSortedTests(TestCase):
                 ['3', '2', '10', '1'],
                 {'strict': True, 'key': int, 'reverse': True},
                 False,
-            ),
-            # We'll do the same weird thing as Python here
-            (['nan', 0, 'nan', 0], {'key': float}, True),
-            ([0, 'nan', 0, 'nan'], {'key': float}, True),
-            (['nan', 0, 'nan', 0], {'key': float, 'reverse': True}, True),
-            ([0, 'nan', 0, 'nan'], {'key': float, 'reverse': True}, True),
-            ([0, 'nan', 0, 'nan'], {'strict': True, 'key': float}, True),
-            (
-                ['nan', 0, 'nan', 0],
-                {'strict': True, 'key': float, 'reverse': True},
-                True,
             ),
         ]:
             key = kwargs.get('key', None)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4322,6 +4322,17 @@ class SampleTests(TestCase):
         self.assertTrue(difference_in_means < 4.4)
 
 
+class BarelySortable:
+    def __init__(self, value):
+        self.value = value
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+    def __int__(self):
+        return int(self.value)
+
+
 class IsSortedTests(TestCase):
     def test_basic(self):
         for iterable, kwargs, expected in [
@@ -4370,7 +4381,10 @@ class IsSortedTests(TestCase):
                 iterable=iterable, key=key, reverse=reverse, strict=strict
             ):
                 mi_result = mi.is_sorted(
-                    iter(iterable), key=key, reverse=reverse, strict=strict
+                    map(BarelySortable, iterable),
+                    key=key,
+                    reverse=reverse,
+                    strict=strict,
                 )
 
                 sorted_iterable = sorted(iterable, key=key, reverse=reverse)


### PR DESCRIPTION
This PR updates `is_sorted` to use only `lt` comparisons.

Closes #916