### PR TITLE
Drop Python3.8 support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,3 +32,4 @@ jobs:
       with:
         name: more-itertools-packages
         path: dist/*
+        overwrite: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,14 +22,17 @@ jobs:
     - name: Run tests
       run: make coverage
     - name: Static checks
+      if: "matrix.python-version == '3.9'"
       run: make check
     - name: Build docs with sphinx
+      if: "matrix.python-version == '3.9'"
       run: make docs
     - name: Build packages
+      if: "matrix.python-version == '3.9'"
       run: make package
     - name: Upload packages
+      if: "matrix.python-version == '3.9'"
       uses: actions/upload-artifact@v4
       with:
         name: more-itertools-packages
         path: dist/*
-        overwrite: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,16 +22,12 @@ jobs:
     - name: Run tests
       run: make coverage
     - name: Static checks
-      if: "matrix.python-version == '3.8'"
       run: make check
     - name: Build docs with sphinx
-      if: "matrix.python-version == '3.8'"
       run: make docs
     - name: Build packages
-      if: "matrix.python-version == '3.8'"
       run: make package
     - name: Upload packages
-      if: "matrix.python-version == '3.8'"
       uses: actions/upload-artifact@v4
       with:
         name: more-itertools-packages

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,29 @@
-.PHONY: all-checks
+.PHONY: all-checks check coverage docs format package requirements test
+
 all-checks: requirements coverage check docs package
 
-.PHONY: requirements
 requirements:
 	python3 -m pip install -r requirements/development.txt
 	python3 -m pip install --editable .
 
-.PHONY: check
 check:
 	black --check .
-	flake8 --exclude .venv,venv,docs/conf.py .
+	flake8 more_itertools tests
 	stubtest more_itertools.more more_itertools.recipes
 
-.PHONY: format
 format:
 	black .
 
-.PHONY: coverage
 coverage:
 	coverage run --include="more_itertools/*.py" -m unittest
 	coverage report --show-missing --fail-under=99
 
-.PHONY: test
 test:
 	python3 -m unittest -v ${tests}
 
-.PHONY: docs
 docs:
 	sphinx-build -W -b html docs docs/_build/html
 
-.PHONY: package
 package: requirements
 	flit build --setup-py
 	twine check dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,35 @@
-.PHONY: all-checks check coverage docs format package requirements test
-
+.PHONY: all-checks
 all-checks: requirements coverage check docs package
 
+.PHONY: requirements
 requirements:
 	python3 -m pip install -r requirements/development.txt
 	python3 -m pip install --editable .
 
+.PHONY: check
 check:
 	black --check .
 	flake8 more_itertools tests
 	stubtest more_itertools.more more_itertools.recipes
 
+.PHONY: format
 format:
 	black .
 
+.PHONY: coverage
 coverage:
 	coverage run --include="more_itertools/*.py" -m unittest
 	coverage report --show-missing --fail-under=99
 
+.PHONY: test
 test:
 	python3 -m unittest -v ${tests}
 
+.PHONY: docs
 docs:
 	sphinx-build -W -b html docs docs/_build/html
 
+.PHONY: package
 package: requirements
 	flit build --setup-py
 	twine check dist/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
-import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -218,8 +218,8 @@ def first(iterable, default=_marker):
         return item
     if default is _marker:
         raise ValueError(
-            "first() was called on an empty iterable, "
-            "and no default value was provided."
+            'first() was called on an empty iterable, '
+            'and no default value was provided.'
         )
     return default
 
@@ -246,8 +246,8 @@ def last(iterable, default=_marker):
     except (IndexError, TypeError, StopIteration):
         if default is _marker:
             raise ValueError(
-                "last() was called on an empty iterable, "
-                "and no default value was provided."
+                'last() was called on an empty iterable, '
+                'and no default value was provided.'
             )
         return default
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -218,8 +218,8 @@ def first(iterable, default=_marker):
         return item
     if default is _marker:
         raise ValueError(
-            'first() was called on an empty iterable, and no '
-            'default value was provided.'
+            "first() was called on an empty iterable, "
+            "and no default value was provided."
         )
     return default
 
@@ -240,15 +240,14 @@ def last(iterable, default=_marker):
         if isinstance(iterable, Sequence):
             return iterable[-1]
         # Work around https://bugs.python.org/issue38525
-        elif hasattr(iterable, '__reversed__') and (hexversion != 0x030800F0):
+        if hasattr(iterable, '__reversed__'):
             return next(reversed(iterable))
-        else:
-            return deque(iterable, maxlen=1)[-1]
+        return deque(iterable, maxlen=1)[-1]
     except (IndexError, TypeError, StopIteration):
         if default is _marker:
             raise ValueError(
-                'last() was called on an empty iterable, and no default was '
-                'provided.'
+                "last() was called on an empty iterable, "
+                "and no default value was provided."
             )
         return default
 

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -12,7 +12,6 @@ from typing import (
     ContextManager,
     Generic,
     Hashable,
-    Mapping,
     Iterable,
     Iterator,
     Mapping,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "more-itertools"
 authors = [{name = "Erik Rose", email = "erikrose@grinchcentral.com"}]
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = [
     "itertools",
@@ -24,7 +24,6 @@ classifiers = [
     "Natural Language :: English",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -39,11 +38,12 @@ dynamic = ["version", "description"]
 
 [project.urls]
 Homepage = "https://github.com/more-itertools/more-itertools"
+Documentation = "https://more-itertools.readthedocs.io/en/stable/"
 
 [tool.flit.module]
 name = "more_itertools"
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ["py39"]
 skip-string-normalization = true


### PR DESCRIPTION
### Issue reference
No issue for dropping py3.8 support according to its [end of life](https://endoflife.date/python) date.

### Changes
Removing any dependencies on the Python v3.8, like in:
- the `pyproject.toml` file
- code
- CI/CD pipelines -> "Github Actions" workflows
- Makefile - just hit on occasion

### Checks and tests
`make all-checks`
![make_all-checks](https://github.com/user-attachments/assets/4a0a21c6-f666-47f6-9671-9016221aacbf)

Partially relates to the PR #852 .