### PR TITLE
Add ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,17 @@ _build
 env/
 venv/
 
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
 # IDE files
 .idea
 .vscode
+
+# MacOS stuff
 .DS_Store
 
-# Mypy
-.mypy_cache
-.dmypy.json
+# ruff stuff
+.ruff_cache

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ requirements:
 
 .PHONY: check
 check:
-	black --check .
-	flake8 more_itertools tests
+	ruff check .
+	ruff format --check .
 	stubtest more_itertools.more more_itertools.recipes
 
 .PHONY: format
 format:
-	black .
+	ruff format .
 
 .PHONY: coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ check:
 format:
 	ruff format .
 
+.PHONY: lint
+lint:
+	ruff check --fix .
+
 .PHONY: coverage
 coverage:
 	coverage run --include="more_itertools/*.py" -m unittest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -149,7 +148,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_css_files = ["_static/theme_overrides.css"]
+html_css_files = ['_static/theme_overrides.css']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/more_itertools/__init__.py
+++ b/more_itertools/__init__.py
@@ -1,6 +1,6 @@
 """More routines for operating on iterables, beyond itertools"""
 
-from .more import *  # noqa
-from .recipes import *  # noqa
+from .more import *
+from .recipes import *
 
 __version__ = '10.6.0'

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2563,7 +2563,7 @@ def _islice_helper(it, s):
             if n <= 0:
                 return
 
-            for index, item in islice(cache, 0, n, step):  # noqa: B007
+            for _, item in islice(cache, 0, n, step):
                 yield item
         elif (stop is not None) and (stop < 0):
             # Advance to the start position
@@ -2598,7 +2598,7 @@ def _islice_helper(it, s):
             else:
                 i, j = min(start - len_iter, -1), None
 
-            for index, item in list(cache)[i:j:step]:  # noqa: B007
+            for _, item in list(cache)[i:j:step]:
                 yield item
         else:
             # Advance to the stop position

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import types
-
 from collections.abc import (
     Container,
     Hashable,
@@ -24,6 +23,7 @@ from typing import (
     overload,
     type_check_only,
 )
+
 from typing_extensions import Protocol
 
 __all__ = [
@@ -758,15 +758,11 @@ def nth_permutation(
 ) -> tuple[_T, ...]: ...
 def value_chain(*args: _T | Iterable[_T]) -> Iterable[_T]: ...
 def product_index(element: Iterable[_T], *args: Iterable[_T]) -> int: ...
-def combination_index(
-    element: Iterable[_T], iterable: Iterable[_T]
-) -> int: ...
+def combination_index(element: Iterable[_T], iterable: Iterable[_T]) -> int: ...
 def combination_with_replacement_index(
     element: Iterable[_T], iterable: Iterable[_T]
 ) -> int: ...
-def permutation_index(
-    element: Iterable[_T], iterable: Iterable[_T]
-) -> int: ...
+def permutation_index(element: Iterable[_T], iterable: Iterable[_T]) -> int: ...
 def repeat_each(iterable: Iterable[_T], n: int = ...) -> Iterator[_T]: ...
 
 class countable(Generic[_T], Iterator[_T]):
@@ -849,7 +845,7 @@ def classify_unique(
 class _SupportsLessThan(Protocol):
     def __lt__(self, __other: Any) -> bool: ...
 
-_SupportsLessThanT = TypeVar("_SupportsLessThanT", bound=_SupportsLessThan)
+_SupportsLessThanT = TypeVar('_SupportsLessThanT', bound=_SupportsLessThan)
 
 @overload
 def minmax(
@@ -919,7 +915,7 @@ def filter_map(
 ) -> Iterator[_V]: ...
 def powerset_of_sets(iterable: Iterable[_T]) -> Iterator[set[_T]]: ...
 def join_mappings(
-    **field_to_map: Mapping[_T, _V]
+    **field_to_map: Mapping[_T, _V],
 ) -> dict[_T, dict[str, _V]]: ...
 def doublestarmap(
     func: Callable[..., _T],

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -10,7 +10,6 @@ Some backward-compatible usability improvements have been made.
 
 import math
 import operator
-
 from collections import deque
 from collections.abc import Sized
 from functools import lru_cache, partial
@@ -28,7 +27,7 @@ from itertools import (
     tee,
     zip_longest,
 )
-from random import randrange, sample, choice
+from random import choice, randrange, sample
 from sys import hexversion
 
 __all__ = [
@@ -221,8 +220,8 @@ def all_equal(iterable, key=None):
 
     """
     iterator = groupby(iterable, key)
-    for first in iterator:
-        for second in iterator:
+    for _ in iterator:
+        for _ in iterator:
             return False
         return True
     return True
@@ -1133,7 +1132,7 @@ _perfect_tests = [
 
 @lru_cache
 def _shift_to_odd(n):
-    'Return s, d such that 2**s * d == n'
+    "Return s, d such that 2**s * d == n"
     s = ((n - 1) ^ n).bit_length() - 1
     d = n >> s
     assert (1 << s) * d == n and d & 1 and s >= 0
@@ -1177,7 +1176,7 @@ def is_prime(n):
         return n in {2, 3, 5, 7, 11, 13}
     if not (n & 1 and n % 3 and n % 5 and n % 7 and n % 11 and n % 13):
         return False
-    for limit, bases in _perfect_tests:
+    for limit, bases in _perfect_tests:  # noqa: B007
         if n < limit:
             break
     else:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -410,8 +410,7 @@ def grouper(iterable, n, incomplete='fill', fillvalue=None):
         return _zip_equal(*args)
     if incomplete == 'ignore':
         return zip(*args)
-    else:
-        raise ValueError('Expected fill, strict, or ignore')
+    raise ValueError('Expected fill, strict, or ignore')
 
 
 def roundrobin(*iterables):
@@ -842,7 +841,7 @@ def sliding_window(iterable, n):
     """
     if n > 20:
         return _sliding_window_deque(iterable, n)
-    elif n > 2:
+    elif n > 2:  # noqa: RET505
         return _sliding_window_islice(iterable, n)
     elif n == 2:
         return pairwise(iterable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,26 @@ Documentation = "https://more-itertools.readthedocs.io/en/stable/"
 [tool.flit.module]
 name = "more_itertools"
 
-[tool.black]
-line-length = 79
-target-version = ["py39"]
-skip-string-normalization = true
+[project.optional-dependencies]
+lint = [
+    "ruff >= 0.8",
+]
+
+[tool.ruff]
+indent-width = 4
+line-length = 80
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "UP"]
+ignore = ["B904", "B028", "F841", "E741"]
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "single"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+"__init__.pyi" = ["F401", "F403"]
+"*.py" = ["E731"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,20 @@ line-length = 80
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I", "UP"]
-ignore = ["B904", "B028", "F841", "E741"]
+# https://docs.astral.sh/ruff/rules/
+select = [
+    "B",  # flake8-bugbear
+    "E",  # pycodestyle errors
+    "ERA",  # eradicate
+    "F",  # pyflakes
+    "I",  # isort
+    "RET",  # flake8-return
+    "SLF",  # flake8-self
+    "TID",  # flake8-tidy-imports
+    "UP",  # pyupgrade
+]
+ignore = ["B904", "B028", "E741"]
+fixable = ["I", "TID"]
 
 [tool.ruff.format]
 indent-style = "space"
@@ -66,3 +78,5 @@ skip-magic-trailing-comma = false
 "__init__.py" = ["F401", "F403"]
 "__init__.pyi" = ["F401", "F403"]
 "*.py" = ["E731"]
+"tests/*.py" = ["SLF001"]
+"docs/*.py" = ["ERA001"]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,8 +1,7 @@
-black
 coverage
-flake8
 flit
 mypy
+ruff
 setuptools
 sphinx
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,6 @@ commit = True
 tag = False
 files = more_itertools/__init__.py
 
-[flake8]
-exclude = ./docs/conf.py, .eggs/
-ignore = E203, E731, E741, F999, W503
-
 [mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,6 +1,5 @@
 import cmath
 import warnings
-
 from collections import Counter, abc
 from collections.abc import Set
 from datetime import datetime, timedelta
@@ -22,15 +21,15 @@ from itertools import (
     product,
     repeat,
 )
-from operator import add, mul, itemgetter
-from pickle import loads, dumps
+from operator import add, itemgetter, mul
+from pickle import dumps, loads
 from random import Random, random, randrange, seed
 from statistics import mean
 from string import ascii_letters
 from sys import version_info
 from time import sleep
 from traceback import format_exc
-from unittest import skipIf, TestCase
+from unittest import TestCase, skipIf
 
 import more_itertools as mi
 
@@ -84,7 +83,7 @@ class ChunkedTests(TestCase):
         def f():
             return list(mi.chunked('ABCDE', 3, strict=True))
 
-        self.assertRaisesRegex(ValueError, "iterable is not divisible by n", f)
+        self.assertRaisesRegex(ValueError, 'iterable is not divisible by n', f)
         self.assertEqual(
             list(mi.chunked('ABCDEF', 3, strict=True)),
             [['A', 'B', 'C'], ['D', 'E', 'F']],
@@ -100,7 +99,7 @@ class ChunkedTests(TestCase):
             return list(mi.chunked('ABCDE', None, strict=True))
 
         self.assertRaisesRegex(
-            ValueError, "n must not be None when using strict mode.", f
+            ValueError, 'n must not be None when using strict mode.', f
         )
 
 
@@ -534,9 +533,7 @@ class IlenTests(TestCase):
     def test_ilen(self):
         """Sanity-checks for ``ilen()``."""
         # Non-empty
-        self.assertEqual(
-            mi.ilen(filter(lambda x: x % 10 == 0, range(101))), 11
-        )
+        self.assertEqual(mi.ilen(filter(lambda x: x % 10 == 0, range(101))), 11)
 
         # Empty
         self.assertEqual(mi.ilen(x for x in range(0)), 0)
@@ -575,9 +572,7 @@ class MinMaxTests(TestCase):
 
     def test_iterables(self):
         self.assertTupleEqual(mi.minmax(x for x in [0, 1, 2, 3]), (0, 3))
-        self.assertTupleEqual(
-            mi.minmax(map(str, [3, 5.5, 'a', 2])), ('2', 'a')
-        )
+        self.assertTupleEqual(mi.minmax(map(str, [3, 5.5, 'a', 2])), ('2', 'a'))
         self.assertTupleEqual(
             mi.minmax(filter(None, [0, 3, '', None, 10])), (3, 10)
         )
@@ -646,9 +641,9 @@ class OneTests(TestCase):
         it = count()
         self.assertRaisesRegex(
             ValueError,
-            "Expected exactly one item in "
-            "iterable, but got 0, 1, and "
-            "perhaps more.",
+            'Expected exactly one item in '
+            'iterable, but got 0, 1, and '
+            'perhaps more.',
             lambda: mi.one(it),
         )
 
@@ -658,9 +653,7 @@ class IntersperseTest(TestCase):
 
     def test_even(self):
         iterable = (x for x in '01')
-        self.assertEqual(
-            list(mi.intersperse(None, iterable)), ['0', None, '1']
-        )
+        self.assertEqual(list(mi.intersperse(None, iterable)), ['0', None, '1'])
 
     def test_odd(self):
         iterable = (x for x in '012')
@@ -711,7 +704,7 @@ class UniqueToEachTests(TestCase):
     def test_duplicates(self):
         """When there are duplicates in any of the input iterables that aren't
         in the rest, those duplicates should be emitted."""
-        iterables = ["mississippi", "missouri"]
+        iterables = ['mississippi', 'missouri']
         self.assertEqual(
             mi.unique_to_each(*iterables), [['p', 'p'], ['o', 'u', 'r']]
         )
@@ -1069,11 +1062,11 @@ class InterleaveEvenlyTests(TestCase):
         self.assertEqual(actual, expected)
 
     def test_three_iters(self):
-        a = ["a1", "a2", "a3", "a4", "a5"]
-        b = ["b1", "b2", "b3"]
-        c = ["c1"]
+        a = ['a1', 'a2', 'a3', 'a4', 'a5']
+        b = ['b1', 'b2', 'b3']
+        c = ['c1']
         actual = list(mi.interleave_evenly([a, b, c]))
-        expected = ["a1", "b1", "a2", "c1", "a3", "b2", "a4", "b3", "a5"]
+        expected = ['a1', 'b1', 'a2', 'c1', 'a3', 'b2', 'a4', 'b3', 'a5']
         self.assertEqual(actual, expected)
 
     def test_many_iters(self):
@@ -1083,7 +1076,7 @@ class InterleaveEvenlyTests(TestCase):
         iterables = []
         for ch in ascii_letters:
             length = rng.randint(0, 100)
-            iterable = [f"{ch}{i}" for i in range(length)]
+            iterable = [f'{ch}{i}' for i in range(length)]
             iterables.append(iterable)
 
         interleaved = list(mi.interleave_evenly(iterables))
@@ -1138,13 +1131,13 @@ class TestCollapse(TestCase):
         self.assertEqual(list(mi.collapse(l)), [1, 2, 3, 4, 5])
 
     def test_collapse_to_string(self):
-        l = [["s1"], "s2", [["s3"], "s4"], [[["s5"]]]]
-        self.assertEqual(list(mi.collapse(l)), ["s1", "s2", "s3", "s4", "s5"])
+        l = [['s1'], 's2', [['s3'], 's4'], [[['s5']]]]
+        self.assertEqual(list(mi.collapse(l)), ['s1', 's2', 's3', 's4', 's5'])
 
     def test_collapse_to_bytes(self):
-        l = [[b"s1"], b"s2", [[b"s3"], b"s4"], [[[b"s5"]]]]
+        l = [[b's1'], b's2', [[b's3'], b's4'], [[[b's5']]]]
         self.assertEqual(
-            list(mi.collapse(l)), [b"s1", b"s2", b"s3", b"s4", b"s5"]
+            list(mi.collapse(l)), [b's1', b's2', b's3', b's4', b's5']
         )
 
     def test_collapse_flatten(self):
@@ -1296,7 +1289,7 @@ class SplitAtTests(TestCase):
         ]:
             with self.subTest(iterable=iterable, separator=separator):
                 it = iter(iterable)
-                pred = lambda x: x == separator
+                pred = lambda x: x == separator  # noqa: B023
                 actual = [''.join(x) for x in mi.split_at(it, pred)]
                 expected = iterable.split(separator)
                 self.assertEqual(actual, expected)
@@ -1742,9 +1735,7 @@ class PaddedTest(TestCase):
         self.assertEqual(list(mi.padded(seq, n=5)), [1, 2, 3, 4, 5])
 
         # No fillvalue
-        self.assertEqual(
-            list(mi.padded(seq, n=7)), [1, 2, 3, 4, 5, None, None]
-        )
+        self.assertEqual(list(mi.padded(seq, n=7)), [1, 2, 3, 4, 5, None, None])
 
         # With fillvalue
         self.assertEqual(
@@ -1915,7 +1906,7 @@ class ZipEqualTest(TestCase):
             )
 
         (warning,) = caught
-        assert warning.category == DeprecationWarning
+        assert warning.category is DeprecationWarning
 
     def test_equal(self):
         lists = [0, 1, 2], [2, 3, 4]
@@ -2191,9 +2182,7 @@ class SortTogetherTest(TestCase):
         # Test for iterable of iterables
         self.assertRaises(
             mi.UnequalIterablesError,
-            lambda: mi.sort_together(
-                (range(i) for i in range(4)), strict=True
-            ),
+            lambda: mi.sort_together((range(i) for i in range(4)), strict=True),
         )
 
 
@@ -2266,9 +2255,7 @@ class TestAlwaysIterable(TestCase):
         self.assertEqual(
             list(mi.always_iterable([0, 1], base_type=list)), [[0, 1]]
         )
-        self.assertEqual(
-            list(mi.always_iterable(iter('foo'))), ['f', 'o', 'o']
-        )
+        self.assertEqual(list(mi.always_iterable(iter('foo'))), ['f', 'o', 'o'])
         self.assertEqual(list(mi.always_iterable([])), [])
 
     def test_none(self):
@@ -2387,9 +2374,7 @@ class AdjacentTests(TestCase):
         self.assertRaises(
             ValueError, lambda: mi.adjacent(pred, range(1000), -1)
         )
-        self.assertRaises(
-            ValueError, lambda: mi.adjacent(pred, range(10), -10)
-        )
+        self.assertRaises(ValueError, lambda: mi.adjacent(pred, range(10), -10))
 
     def test_grouping(self):
         """Test interaction of adjacent() with groupby_transform()"""
@@ -2515,11 +2500,11 @@ class NumericRangeTests(TestCase):
             ((0.1, 0.30000000000000001, 0.2), [0.1]),  # IEE 754 !
             (
                 (
-                    Decimal("0.1"),
-                    Decimal("0.30000000000000001"),
-                    Decimal("0.2"),
+                    Decimal('0.1'),
+                    Decimal('0.30000000000000001'),
+                    Decimal('0.2'),
                 ),
-                [Decimal("0.1"), Decimal("0.3")],
+                [Decimal('0.1'), Decimal('0.3')],
             ),  # okay with Decimal
             (
                 (
@@ -2570,7 +2555,7 @@ class NumericRangeTests(TestCase):
                 timedelta(minutes=0),
             ),
             (1.0, 2.0, 0.0),
-            (Decimal("1.0"), Decimal("2.0"), Decimal("0.0")),
+            (Decimal('1.0'), Decimal('2.0'), Decimal('0.0')),
             (Fraction(2, 2), Fraction(4, 2), Fraction(0, 2)),
         ]:
             with self.assertRaises(ValueError):
@@ -2586,8 +2571,8 @@ class NumericRangeTests(TestCase):
             ((2.0, 1.0, -1.5), True),
             ((1.0, 1.0, -1.5), False),
             ((0.0, 1.0, -1.5), False),
-            ((Decimal("1.0"), Decimal("2.0"), Decimal("1.5")), True),
-            ((Decimal("1.0"), Decimal("0.0"), Decimal("1.5")), False),
+            ((Decimal('1.0'), Decimal('2.0'), Decimal('1.5')), True),
+            ((Decimal('1.0'), Decimal('0.0'), Decimal('1.5')), False),
             ((Fraction(2, 2), Fraction(4, 2), Fraction(3, 2)), True),
             ((Fraction(2, 2), Fraction(0, 2), Fraction(3, 2)), False),
             (
@@ -2615,16 +2600,16 @@ class NumericRangeTests(TestCase):
             ((1.0, 9.9, 1.5), (1.0, 2.5, 4.0, 5.5, 7.0, 8.5), (0.9,)),
             ((9.0, 1.0, -1.5), (1.5, 3.0, 4.5, 6.0, 7.5, 9.0), (0.0, 0.9)),
             (
-                (Decimal("1.0"), Decimal("9.9"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('9.9'), Decimal('1.5')),
                 (
-                    Decimal("1.0"),
-                    Decimal("2.5"),
-                    Decimal("4.0"),
-                    Decimal("5.5"),
-                    Decimal("7.0"),
-                    Decimal("8.5"),
+                    Decimal('1.0'),
+                    Decimal('2.5'),
+                    Decimal('4.0'),
+                    Decimal('5.5'),
+                    Decimal('7.0'),
+                    Decimal('8.5'),
                 ),
-                (Decimal("0.9"),),
+                (Decimal('0.9'),),
             ),
             (
                 (Fraction(0, 1), Fraction(5, 1), Fraction(1, 2)),
@@ -2657,8 +2642,8 @@ class NumericRangeTests(TestCase):
             ((8.5, 0.0, -1.5), (8.5, 0.7, -1.5)),
             ((7.0, 0.0, 1.0), (17.0, 7.0, 0.5)),
             (
-                (Decimal("1.0"), Decimal("9.9"), Decimal("1.5")),
-                (Decimal("1.0"), Decimal("8.6"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('9.9'), Decimal('1.5')),
+                (Decimal('1.0'), Decimal('8.6'), Decimal('1.5')),
             ),
             (
                 (Fraction(1, 1), Fraction(10, 1), Fraction(3, 2)),
@@ -2677,9 +2662,7 @@ class NumericRangeTests(TestCase):
                 ),
             ),
         ]:
-            self.assertEqual(
-                mi.numeric_range(*args1), mi.numeric_range(*args2)
-            )
+            self.assertEqual(mi.numeric_range(*args1), mi.numeric_range(*args2))
 
         for args1, args2 in [
             ((0, 5, 2), (0, 7, 2)),
@@ -2691,8 +2674,8 @@ class NumericRangeTests(TestCase):
             ((8.5, 0.0, -1.5), (8.5, 0.0, -1.4)),
             ((0.0, 7.0, 1.0), (7.0, 0.0, 1.0)),
             (
-                (Decimal("1.0"), Decimal("10.0"), Decimal("1.5")),
-                (Decimal("1.0"), Decimal("10.5"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('10.0'), Decimal('1.5')),
+                (Decimal('1.0'), Decimal('10.5'), Decimal('1.5')),
             ),
             (
                 (Fraction(1, 1), Fraction(10, 1), Fraction(3, 2)),
@@ -2716,7 +2699,7 @@ class NumericRangeTests(TestCase):
             )
 
         self.assertNotEqual(mi.numeric_range(7.0), 1)
-        self.assertNotEqual(mi.numeric_range(7.0), "abc")
+        self.assertNotEqual(mi.numeric_range(7.0), 'abc')
 
     def test_get_item_by_index(self):
         for args, index, expected in [
@@ -2728,9 +2711,9 @@ class NumericRangeTests(TestCase):
             ((1.0, 6.0, 1.5), -1, 5.5),
             ((1.0, 6.0, 1.5), -2, 4.0),
             (
-                (Decimal("1.0"), Decimal("9.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('9.0'), Decimal('1.5')),
                 -1,
-                Decimal("8.5"),
+                Decimal('8.5'),
             ),
             (
                 (Fraction(1, 1), Fraction(10, 1), Fraction(3, 2)),
@@ -2754,7 +2737,7 @@ class NumericRangeTests(TestCase):
             ((1.0, 6.0, 1.5), -5),
             ((6.0, 1.0, 1.5), 0),
             ((6.0, 1.0, 1.5), -1),
-            ((Decimal("1.0"), Decimal("9.0"), Decimal("-1.5")), -1),
+            ((Decimal('1.0'), Decimal('9.0'), Decimal('-1.5')), -1),
             ((Fraction(1, 1), Fraction(2, 1), Fraction(3, 2)), 2),
             (
                 (
@@ -2781,9 +2764,9 @@ class NumericRangeTests(TestCase):
             ((1.0, 9.0, 1.5), slice(None, -10, 3), (1.0, 1.0, 4.5)),
             ((1.0, 9.0, 1.5), slice(None, 10, 3), (1.0, 9.0, 4.5)),
             (
-                (Decimal("1.0"), Decimal("9.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('9.0'), Decimal('1.5')),
                 slice(1, -1, None),
-                (Decimal("2.5"), Decimal("8.5"), Decimal("1.5")),
+                (Decimal('2.5'), Decimal('8.5'), Decimal('1.5')),
             ),
             (
                 (Fraction(1, 1), Fraction(5, 1), Fraction(3, 2)),
@@ -2817,8 +2800,8 @@ class NumericRangeTests(TestCase):
             ((1.5, 1.0, 1.5), hash(range(0, 0))),
             ((1.5, 1.5, 1.5), hash(range(0, 0))),
             (
-                (Decimal("1.0"), Decimal("9.0"), Decimal("1.5")),
-                hash((Decimal("1.0"), Decimal("8.5"), Decimal("1.5"))),
+                (Decimal('1.0'), Decimal('9.0'), Decimal('1.5')),
+                hash((Decimal('1.0'), Decimal('8.5'), Decimal('1.5'))),
             ),
             (
                 (Fraction(1, 1), Fraction(5, 1), Fraction(3, 2)),
@@ -2858,13 +2841,13 @@ class NumericRangeTests(TestCase):
             ((0.1, 0.30000000000000001, 0.2), 1),  # IEE 754 !
             (
                 (
-                    Decimal("0.1"),
-                    Decimal("0.30000000000000001"),
-                    Decimal("0.2"),
+                    Decimal('0.1'),
+                    Decimal('0.30000000000000001'),
+                    Decimal('0.2'),
                 ),
                 2,
             ),  # works with Decimal
-            ((Decimal("1.0"), Decimal("9.0"), Decimal("1.5")), 6),
+            ((Decimal('1.0'), Decimal('9.0'), Decimal('1.5')), 6),
             ((Fraction(1, 1), Fraction(5, 1), Fraction(3, 2)), 3),
             (
                 (
@@ -2879,11 +2862,11 @@ class NumericRangeTests(TestCase):
 
     def test_repr(self):
         for args, *expected in [
-            ((7.0,), "numeric_range(0.0, 7.0)"),
-            ((1.0, 7.0), "numeric_range(1.0, 7.0)"),
-            ((7.0, 1.0, -1.5), "numeric_range(7.0, 1.0, -1.5)"),
+            ((7.0,), 'numeric_range(0.0, 7.0)'),
+            ((1.0, 7.0), 'numeric_range(1.0, 7.0)'),
+            ((7.0, 1.0, -1.5), 'numeric_range(7.0, 1.0, -1.5)'),
             (
-                (Decimal("1.0"), Decimal("9.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('9.0'), Decimal('1.5')),
                 (
                     "numeric_range(Decimal('1.0'), Decimal('9.0'), "
                     "Decimal('1.5'))"
@@ -2892,8 +2875,8 @@ class NumericRangeTests(TestCase):
             (
                 (Fraction(7, 7), Fraction(10, 2), Fraction(3, 2)),
                 (
-                    "numeric_range(Fraction(1, 1), Fraction(5, 1), "
-                    "Fraction(3, 2))"
+                    'numeric_range(Fraction(1, 1), Fraction(5, 1), '
+                    'Fraction(3, 2))'
                 ),
             ),
             (
@@ -2902,12 +2885,12 @@ class NumericRangeTests(TestCase):
                     datetime(2019, 3, 30),
                     timedelta(hours=10),
                 ),
-                "numeric_range(datetime.datetime(2019, 3, 29, 0, 0), "
-                "datetime.datetime(2019, 3, 30, 0, 0), "
-                "datetime.timedelta(seconds=36000))",
-                "numeric_range(datetime.datetime(2019, 3, 29, 0, 0), "
-                "datetime.datetime(2019, 3, 30, 0, 0), "
-                "datetime.timedelta(0, 36000))",
+                'numeric_range(datetime.datetime(2019, 3, 29, 0, 0), '
+                'datetime.datetime(2019, 3, 30, 0, 0), '
+                'datetime.timedelta(seconds=36000))',
+                'numeric_range(datetime.datetime(2019, 3, 29, 0, 0), '
+                'datetime.datetime(2019, 3, 30, 0, 0), '
+                'datetime.timedelta(0, 36000))',
             ),
         ]:
             with self.subTest(args=args):
@@ -2920,7 +2903,7 @@ class NumericRangeTests(TestCase):
             ((7.0, 1.0, -1.5), [2.5, 4.0, 5.5, 7.0]),
             ((7.0, 0.9, -1.5), [1.0, 2.5, 4.0, 5.5, 7.0]),
             (
-                (Decimal("1.0"), Decimal("5.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('5.0'), Decimal('1.5')),
                 [Decimal('4.0'), Decimal('2.5'), Decimal('1.0')],
             ),
             (
@@ -2950,7 +2933,7 @@ class NumericRangeTests(TestCase):
             ((7.0,), 7.0, 0),
             ((7.0,), 10.0, 0),
             (
-                (Decimal("1.0"), Decimal("5.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('5.0'), Decimal('1.5')),
                 Decimal('4.0'),
                 1,
             ),
@@ -2978,7 +2961,7 @@ class NumericRangeTests(TestCase):
             ((7.0, 0.0, -1.0), 7.0, 0),
             ((7.0, 0.0, -1.0), 1.0, 6),
             (
-                (Decimal("1.0"), Decimal("5.0"), Decimal("1.5")),
+                (Decimal('1.0'), Decimal('5.0'), Decimal('1.5')),
                 Decimal('4.0'),
                 2,
             ),
@@ -3007,7 +2990,7 @@ class NumericRangeTests(TestCase):
             ((7.0, 0.0, -1.0), 0.0),
             ((7.0, 0.0, -1.0), 10.0),
             ((7.0, 0.0), 5.0),
-            ((Decimal("1.0"), Decimal("5.0"), Decimal("1.5")), Decimal('4.5')),
+            ((Decimal('1.0'), Decimal('5.0'), Decimal('1.5')), Decimal('4.5')),
             ((Fraction(1, 1), Fraction(5, 1), Fraction(3, 2)), Fraction(5, 3)),
             (
                 (
@@ -3048,7 +3031,7 @@ class NumericRangeTests(TestCase):
             (7.0, 5.0),
             (7.0, 5.0, 4.0),
             (7.0, 5.0, -1.0),
-            (Decimal("1.0"), Decimal("5.0"), Decimal("1.5")),
+            (Decimal('1.0'), Decimal('5.0'), Decimal('1.5')),
             (Fraction(1, 1), Fraction(5, 1), Fraction(3, 2)),
             (datetime(2019, 3, 29), datetime(2019, 3, 30)),
         ]:
@@ -3384,18 +3367,18 @@ class SeekableTest(PeekableMixinTests, TestCase):
 class SequenceViewTests(TestCase):
     def test_init(self):
         view = mi.SequenceView((1, 2, 3))
-        self.assertEqual(repr(view), "SequenceView((1, 2, 3))")
+        self.assertEqual(repr(view), 'SequenceView((1, 2, 3))')
         self.assertRaises(TypeError, lambda: mi.SequenceView({}))
 
     def test_update(self):
         seq = [1, 2, 3]
         view = mi.SequenceView(seq)
         self.assertEqual(len(view), 3)
-        self.assertEqual(repr(view), "SequenceView([1, 2, 3])")
+        self.assertEqual(repr(view), 'SequenceView([1, 2, 3])')
 
         seq.pop()
         self.assertEqual(len(view), 2)
-        self.assertEqual(repr(view), "SequenceView([1, 2])")
+        self.assertEqual(repr(view), 'SequenceView([1, 2])')
 
     def test_indexing(self):
         seq = ('a', 'b', 'c', 'd', 'e', 'f')
@@ -3677,7 +3660,7 @@ class RlocateTests(TestCase):
     def test_window_size_large(self):
         iterable = [1, 2, 3, 4]
         pred = lambda a, b, c, d, e: True
-        for it in (iterable, iter(iterable)):
+        for _ in (iterable, iter(iterable)):
             actual = list(mi.rlocate(iterable, pred, window_size=5))
             expected = [0]
             self.assertEqual(actual, expected)
@@ -3685,7 +3668,7 @@ class RlocateTests(TestCase):
     def test_window_size_zero(self):
         iterable = [1, 2, 3, 4]
         pred = lambda: True
-        for it in (iterable, iter(iterable)):
+        for _ in (iterable, iter(iterable)):
             with self.assertRaises(ValueError):
                 list(mi.locate(iterable, pred, window_size=0))
 
@@ -4012,7 +3995,7 @@ class OnlyTests(TestCase):
     def test_default_exception_message(self):
         self.assertRaisesRegex(
             ValueError,
-            "Expected exactly one item in iterable, "
+            'Expected exactly one item in iterable, '
             "but got 'foo', 'bar', and perhaps more",
             lambda: mi.only(['foo', 'bar', 'baz']),
         )
@@ -4137,7 +4120,7 @@ class FilterExceptTests(TestCase):
             list(mi.filter_except(int, iterable))
 
     def test_raise(self):
-        iterable = ['0', '1' '2', 'three', None]
+        iterable = ['0', '12', 'three', None]
         with self.assertRaises(TypeError):
             list(mi.filter_except(int, iterable, ValueError))
 
@@ -4169,7 +4152,7 @@ class MapExceptTests(TestCase):
             list(mi.map_except(int, iterable))
 
     def test_raise(self):
-        iterable = ['0', '1' '2', 'three', None]
+        iterable = ['0', '12', 'three', None]
         with self.assertRaises(TypeError):
             list(mi.map_except(int, iterable, ValueError))
 
@@ -4210,7 +4193,7 @@ class SampleTests(TestCase):
         # If the algorithm is changed (e.g. to a more naive implementation)
         # this test will fail, but the algorithm might be correct.
         # Also, this test can pass and the algorithm can be completely wrong.
-        data = "abcdef"
+        data = 'abcdef'
         weights = list(range(1, len(data) + 1))
         seed(123)
         actual = mi.sample(data, k=2, weights=weights)
@@ -4259,7 +4242,7 @@ class SampleTests(TestCase):
 
     def test_sampling_entire_iterable(self):
         """If k=len(iterable), the sample contains the original elements."""
-        data = ["a", 2, "a", 4, (1, 2, 3)]
+        data = ['a', 2, 'a', 4, (1, 2, 3)]
         actual = set(mi.sample(data, k=len(data)))
         expected = set(data)
         self.assertEqual(actual, expected)
@@ -4267,7 +4250,7 @@ class SampleTests(TestCase):
     def test_scale_invariance_of_weights(self):
         """The probability of choosing element a_i is w_i / sum(weights).
         Scaling weights should not change the probability or outcome."""
-        data = "abcdef"
+        data = 'abcdef'
 
         weights = list(range(1, len(data) + 1))
         seed(123)
@@ -4311,8 +4294,7 @@ class SampleTests(TestCase):
             mean(mi.sample(data, k=50, weights=data)) for _ in range(10)
         ]
         data_rev_means = [
-            mean(mi.sample(data_rev, k=50, weights=data_rev))
-            for _ in range(10)
+            mean(mi.sample(data_rev, k=50, weights=data_rev)) for _ in range(10)
         ]
 
         # The difference in the means should be low, i.e. little bias
@@ -4322,7 +4304,6 @@ class SampleTests(TestCase):
         self.assertTrue(difference_in_means < 4.4)
 
     def test_error_cases(self):
-
         # weights and counts are mutally exclusive
         with self.assertRaises(TypeError):
             mi.sample(
@@ -4476,13 +4457,13 @@ class CallbackIterTests(TestCase):
             self.assertEqual(next(it), ((1, 'a'), {'intermediate_total': 1}))
 
         with self.assertRaises(mi.AbortThread):
-            it.result
+            it.result  # noqa: B018
 
     def test_no_result(self):
         func = lambda callback=None: self._target(cb=callback)
         with mi.callback_iter(func) as it:
             with self.assertRaises(RuntimeError):
-                it.result
+                it.result  # noqa: B018
 
     def test_exception(self):
         func = lambda callback=None: self._target(cb=callback, exc=ValueError)
@@ -4493,7 +4474,7 @@ class CallbackIterTests(TestCase):
             )
 
             with self.assertRaises(ValueError):
-                it.result
+                it.result  # noqa: B018
 
 
 class WindowedCompleteTests(TestCase):
@@ -4564,12 +4545,8 @@ class AllUniqueTests(TestCase):
 
     def test_partially_hashable(self):
         self.assertEqual(mi.all_unique([[1, 2], [3, 4], (5, 6)]), True)
-        self.assertEqual(
-            mi.all_unique([[1, 2], [3, 4], (5, 6), [1, 2]]), False
-        )
-        self.assertEqual(
-            mi.all_unique([[1, 2], [3, 4], (5, 6), (5, 6)]), False
-        )
+        self.assertEqual(mi.all_unique([[1, 2], [3, 4], (5, 6), [1, 2]]), False)
+        self.assertEqual(mi.all_unique([[1, 2], [3, 4], (5, 6), (5, 6)]), False)
 
     def test_key(self):
         iterable = ['A', 'B', 'C', 'b']
@@ -4910,7 +4887,7 @@ class ChunkedEvenTests(TestCase):
             def count_with_assert():
                 for i in count():
                     # Look-ahead should be less than n^2
-                    self.assertLessEqual(i, n * k + n * n)
+                    self.assertLessEqual(i, n * k + n * n)  # noqa: B023
                     yield i
 
             ls = mi.chunked_even(count_with_assert(), n)
@@ -5207,9 +5184,7 @@ class DuplicatesJustSeenTests(TestCase):
         self.assertEqual(list(mi.duplicates_justseen([[1, 2], [3, 4]])), [])
         self.assertEqual(
             list(
-                mi.duplicates_justseen(
-                    [[1, 2], [3, 4], [3, 4], [3, 4], [1, 2]]
-                )
+                mi.duplicates_justseen([[1, 2], [3, 4], [3, 4], [3, 4], [1, 2]])
             ),
             [[3, 4], [3, 4]],
         )
@@ -5220,17 +5195,13 @@ class DuplicatesJustSeenTests(TestCase):
         )
         self.assertEqual(
             list(
-                mi.duplicates_justseen(
-                    [[1, 2], [3, 4], (5, 6), [1, 2], [1, 2]]
-                )
+                mi.duplicates_justseen([[1, 2], [3, 4], (5, 6), [1, 2], [1, 2]])
             ),
             [[1, 2]],
         )
         self.assertEqual(
             list(
-                mi.duplicates_justseen(
-                    [[1, 2], [3, 4], (5, 6), (5, 6), (5, 6)]
-                )
+                mi.duplicates_justseen([[1, 2], [3, 4], (5, 6), (5, 6), (5, 6)])
             ),
             [(5, 6), (5, 6)],
         )
@@ -5436,9 +5407,7 @@ class ClassifyUniqueTests(TestCase):
             e for e, j, u in mi.classify_unique(input, str.lower) if not u
         ]
         self.assertEqual(output, list('heHEhe'))
-        self.assertEqual(
-            list(mi.duplicates_everseen(input, str.lower)), output
-        )
+        self.assertEqual(list(mi.duplicates_everseen(input, str.lower)), output)
 
     def test_vs_duplicates_justseen(self):
         input = [1, 2, 3, 3, 2, 2]
@@ -5452,9 +5421,7 @@ class ClassifyUniqueTests(TestCase):
             e for e, j, u in mi.classify_unique(input, str.lower) if not j
         ]
         self.assertEqual(output, list('HHheEe'))
-        self.assertEqual(
-            list(mi.duplicates_justseen(input, str.lower)), output
-        )
+        self.assertEqual(list(mi.duplicates_justseen(input, str.lower)), output)
 
 
 class LongestCommonPrefixTests(TestCase):
@@ -5506,30 +5473,30 @@ class LongestCommonPrefixTests(TestCase):
 
 class IequalsTests(TestCase):
     def test_basic(self):
-        self.assertTrue(mi.iequals("abc", iter("abc")))
+        self.assertTrue(mi.iequals('abc', iter('abc')))
         self.assertTrue(mi.iequals(range(3), [0, 1, 2]))
-        self.assertFalse(mi.iequals("abc", [0, 1, 2]))
+        self.assertFalse(mi.iequals('abc', [0, 1, 2]))
 
     def test_no_iterables(self):
         self.assertTrue(mi.iequals())
 
     def test_one_iterable(self):
-        self.assertTrue(mi.iequals("abc"))
+        self.assertTrue(mi.iequals('abc'))
 
     def test_more_than_two_iterable(self):
-        self.assertTrue(mi.iequals("abc", iter("abc"), ['a', 'b', 'c']))
-        self.assertFalse(mi.iequals("abc", iter("abc"), ['a', 'b', 'd']))
+        self.assertTrue(mi.iequals('abc', iter('abc'), ['a', 'b', 'c']))
+        self.assertFalse(mi.iequals('abc', iter('abc'), ['a', 'b', 'd']))
 
     def test_order_matters(self):
-        self.assertFalse(mi.iequals("abc", "acb"))
+        self.assertFalse(mi.iequals('abc', 'acb'))
 
     def test_not_equal_lengths(self):
-        self.assertFalse(mi.iequals("abc", "ab"))
-        self.assertFalse(mi.iequals("abc", "bc"))
-        self.assertFalse(mi.iequals("aaa", "aaaa"))
+        self.assertFalse(mi.iequals('abc', 'ab'))
+        self.assertFalse(mi.iequals('abc', 'bc'))
+        self.assertFalse(mi.iequals('aaa', 'aaaa'))
 
     def test_empty_iterables(self):
-        self.assertTrue(mi.iequals([], ""))
+        self.assertTrue(mi.iequals([], ''))
 
     def test_none_is_not_a_sentinel(self):
         # See https://stackoverflow.com/a/900444
@@ -5645,7 +5612,7 @@ class GrayProductTests(TestCase):
     def test_basic(self):
         self.assertEqual(
             tuple(mi.gray_product(('a', 'b', 'c'), range(1, 3))),
-            (("a", 1), ("b", 1), ("c", 1), ("c", 2), ("b", 2), ("a", 2)),
+            (('a', 1), ('b', 1), ('c', 1), ('c', 2), ('b', 2), ('a', 2)),
         )
         out = mi.gray_product(('foo', 'bar'), (3, 4, 5, 6), ['quz', 'baz'])
         self.assertEqual(next(out), ('foo', 3, 'quz'))
@@ -5680,11 +5647,11 @@ class GrayProductTests(TestCase):
 
     def test_vs_product(self):
         iters = (
-            ("a", "b"),
+            ('a', 'b'),
             range(3, 6),
             [None, None],
-            {"i", "j", "k", "l"},
-            "XYZ",
+            {'i', 'j', 'k', 'l'},
+            'XYZ',
         )
         self.assertEqual(
             sorted(product(*iters)), sorted(mi.gray_product(*iters))

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -3,8 +3,8 @@ from doctest import DocTestSuite
 from fractions import Fraction
 from functools import reduce
 from itertools import combinations, count, groupby, permutations
-from operator import mul
 from math import comb, factorial
+from operator import mul
 from sys import version_info
 from unittest import TestCase, skipIf
 from unittest.mock import patch
@@ -127,7 +127,7 @@ class NthTests(TestCase):
     def test_default(self):
         """Ensure a default value is returned when nth item not found"""
         l = range(3)
-        self.assertEqual(mi.nth(l, 100, "zebra"), "zebra")
+        self.assertEqual(mi.nth(l, 100, 'zebra'), 'zebra')
 
     def test_negative_item_raises(self):
         """Ensure asking for a negative item raises an exception"""
@@ -206,11 +206,9 @@ class NcyclesTests(TestCase):
 
     def test_happy_path(self):
         """cycle a sequence three times"""
-        r = ["a", "b", "c"]
+        r = ['a', 'b', 'c']
         n = mi.ncycles(r, 3)
-        self.assertEqual(
-            ["a", "b", "c", "a", "b", "c", "a", "b", "c"], list(n)
-        )
+        self.assertEqual(['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'], list(n))
 
     def test_null_case(self):
         """asking for 0 cycles should return an empty iterator"""
@@ -279,7 +277,7 @@ class PairwiseTests(TestCase):
 
     def test_short_case(self):
         """ensure an empty iterator if there's not enough values to pair"""
-        p = mi.pairwise("a")
+        p = mi.pairwise('a')
         self.assertRaises(StopIteration, lambda: next(p))
 
     def test_coverage(self):
@@ -531,9 +529,7 @@ class FirstTrueTests(TestCase):
 
     def test_pred(self):
         """Test with a custom predicate"""
-        self.assertEqual(
-            mi.first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6
-        )
+        self.assertEqual(mi.first_true([2, 4, 6], pred=lambda x: x % 3 == 0), 6)
 
 
 class RandomProductTests(TestCase):
@@ -593,7 +589,7 @@ class RandomPermutationTests(TestCase):
         r = mi.random_permutation(i)
         self.assertEqual(set(i), set(r))
         if i == r:
-            raise AssertionError("Values were not permuted")
+            raise AssertionError('Values were not permuted')
 
     def test_partial_permutation(self):
         """ensure all returned items are from the iterable, that the returned
@@ -651,7 +647,7 @@ class RandomCombinationWithReplacementTests(TestCase):
         combo = mi.random_combination_with_replacement(items, len(items) * 2)
         self.assertEqual(2 * len(items), len(combo))
         if len(set(combo)) == len(combo):
-            raise AssertionError("Combination contained no duplicates")
+            raise AssertionError('Combination contained no duplicates')
 
     def test_pseudorandomness(self):
         """ensure different subsets of the iterable get returned over many
@@ -815,7 +811,7 @@ class BeforeAndAfterTests(TestCase):
                 operation = next(events)
             except StopIteration:
                 break
-            assert operation in ["SUM", "MULTIPLY"]
+            assert operation in ['SUM', 'MULTIPLY']
 
             # Here, the remainder `events` is passed into `before_and_after`
             # again, which would be problematic if the remainder is a
@@ -828,14 +824,14 @@ class BeforeAndAfterTests(TestCase):
             yield (operation, numbers)
 
     def test_nested_remainder(self):
-        events = ["SUM", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
-        events += ["MULTIPLY", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
+        events = ['SUM', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
+        events += ['MULTIPLY', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 1000
 
         for operation, numbers in self._group_events(events):
-            if operation == "SUM":
+            if operation == 'SUM':
                 res = sum(numbers)
                 self.assertEqual(res, 55)
-            elif operation == "MULTIPLY":
+            elif operation == 'MULTIPLY':
                 res = reduce(lambda a, b: a * b, numbers)
                 self.assertEqual(res, 3628800)
 
@@ -1171,9 +1167,7 @@ class FactorTests(TestCase):
             all(set(mi.factor(n)) <= set(mi.sieve(n + 1)) for n in range(2000))
         )
         self.assertTrue(
-            all(
-                list(mi.factor(n)) == sorted(mi.factor(n)) for n in range(2000)
-            )
+            all(list(mi.factor(n)) == sorted(mi.factor(n)) for n in range(2000))
         )
 
 


### PR DESCRIPTION
### Issue reference

Addresses the issue #933 .
Must follow the PR #942 .
Allows to close the PR #852 .

### Changes
Tons of them anout formatting and linting the code according to the configuration (which is discussable) from the `pyproject.toml` file:
- docs 
- more_itertools
- tests

### Checks and tests
- `pytest .` - no changes in code and tests apart refactoring
- `uv run --with ruff ruff check --fix .` - no error code reported

![Screenshot from 2024-12-20 16-51-01](https://github.com/user-attachments/assets/239bd6c0-428d-4762-9c00-d32efe99c3cc)

UPD: warning gone (the [comment](https://github.com/more-itertools/more-itertools/pull/934#issuecomment-2580878173)).

**Notes**:
- adopting the `ruff` tool can make the `black` formatting package redundant;
- the same about flake8 and many other linters.

**Updates**.

Some changes cover a total elimination of Py3.8 support ( I should have run `pyupgrade py39-plus ...` in the #928 ).