### PR TITLE
Pin mypy to 1.13.0.  Sticking plaster fix for #935.

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,7 +2,7 @@ black
 coverage
 flake8
 flit
-mypy
+mypy==1.13
 setuptools
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
### Issue reference
Sticking plaster fix for #935.  

It would be better to fix #935 properly, and actually address the underlying issue, by satisfying stubtest and adding whatever is missing.  This would allow us to stick with the latest version of mypy.  But I leave that decision to the maintainers.

### Changes
Pin mypy to 1.13.0.  This is the latest version I found, under which stubtest passed (in make check, in more-itertools' CI job)

### Checks and tests
Passes
