### PR TITLE
`pyupgrade` the code base with `--py39-plus` flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pip-log.txt
 .noseids
 htmlcov/
 coverage.xml
+.pytest_cache
 
 # Docs by Sphinx
 _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import more_itertools
 # to readthedocs.io for display on github.com, but those links can be
 # relative when being built for Sphinx.
 
-with open('../README.rst', 'rt') as source:
+with open('../README.rst') as source:
     readme_file = source.readlines()
 
 build_dir = '_build'
@@ -35,7 +35,7 @@ os.makedirs(build_dir, exist_ok=True)
 rtd_path = 'https://more-itertools.readthedocs.io/en/stable/'
 table_width = 200
 in_table = False
-with open(os.path.join('.', build_dir, 'README.pprst'), 'wt') as target:
+with open(os.path.join('.', build_dir, 'README.pprst'), 'w') as target:
     for line in readme_file:
         old_len = len(line)
         if line.startswith('|') and line.endswith('|\n'):  # Inside table

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -574,8 +574,8 @@ def one(iterable, too_short=None, too_long=None):
         pass
     else:
         msg = (
-            'Expected exactly one item in iterable, but got {!r}, {!r}, '
-            'and perhaps more.'.format(first_value, second_value)
+            f'Expected exactly one item in iterable, but got {first_value!r}, '
+            f'{second_value!r}, and perhaps more.'
         )
         raise too_long or ValueError(msg)
 
@@ -2250,13 +2250,11 @@ class numeric_range(abc.Sequence, abc.Hashable):
             self._start, self._stop, self._step = args
         elif argc == 0:
             raise TypeError(
-                'numeric_range expected at least '
-                '1 argument, got {}'.format(argc)
+                f'numeric_range expected at least 1 argument, got {argc}'
             )
         else:
             raise TypeError(
-                'numeric_range expected at most '
-                '3 arguments, got {}'.format(argc)
+                f'numeric_range expected at most 3 arguments, got {argc}'
             )
 
         self._zero = type(self._step)(0)
@@ -2319,7 +2317,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
         else:
             raise TypeError(
                 'numeric range indices must be '
-                'integers or slices, not {}'.format(type(key).__name__)
+                f'integers or slices, not {type(key).__name__}'
             )
 
     def __hash__(self):
@@ -2360,7 +2358,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
 
     def __repr__(self):
         if self._step == 1:
-            return "numeric_range({self._start!r}, {self._stop!r})"
+            return f"numeric_range({self._start!r}, {self._stop!r})"
         return (
             f"numeric_range({self._start!r}, {self._stop!r}, {self._step!r})"
         )
@@ -3523,8 +3521,8 @@ def only(iterable, default=None, too_long=None):
         pass
     else:
         msg = (
-            'Expected exactly one item in iterable, but got {!r}, {!r}, '
-            'and perhaps more.'.format(first_value, second_value)
+            f'Expected exactly one item in iterable, but got {first_value!r}, '
+            f'{second_value!r}, and perhaps more.'
         )
         raise too_long or ValueError(msg)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -636,13 +636,13 @@ def strictly_n(iterable, n, too_short=None, too_long=None):
     if too_short is None:
         too_short = lambda item_count: raise_(
             ValueError,
-            'Too few items in iterable (got {})'.format(item_count),
+            f'Too few items in iterable (got {item_count})',
         )
 
     if too_long is None:
         too_long = lambda item_count: raise_(
             ValueError,
-            'Too many items in iterable (got at least {})'.format(item_count),
+            f'Too many items in iterable (got at least {item_count})',
         )
 
     it = iter(iterable)
@@ -2390,7 +2390,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
                 if r == self._zero:
                     return int(q)
 
-        raise ValueError("{} is not in numeric range".format(value))
+        raise ValueError(f"{value} is not in numeric range")
 
     def _get_by_index(self, i):
         if i < 0:
@@ -2864,7 +2864,7 @@ class SequenceView(Sequence):
         return len(self._target)
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, repr(self._target))
+        return f'{self.__class__.__name__}({repr(self._target)})'
 
 
 class seekable:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2360,13 +2360,10 @@ class numeric_range(abc.Sequence, abc.Hashable):
 
     def __repr__(self):
         if self._step == 1:
-            return "numeric_range({}, {})".format(
-                repr(self._start), repr(self._stop)
-            )
-        else:
-            return "numeric_range({}, {}, {})".format(
-                repr(self._start), repr(self._stop), repr(self._step)
-            )
+            return "numeric_range({self._start!r}, {self._stop!r})"
+        return (
+            f"numeric_range({self._start!r}, {self._stop!r}, {self._step!r})"
+        )
 
     def __reversed__(self):
         return iter(
@@ -2864,7 +2861,7 @@ class SequenceView(Sequence):
         return len(self._target)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({repr(self._target)})'
+        return f'{self.__class__.__name__}({self._target!r})'
 
 
 class seekable:

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -5,22 +5,23 @@ from __future__ import annotations
 import sys
 import types
 
-from typing import (
-    Any,
-    Callable,
+from collections.abc import (
     Container,
-    ContextManager,
-    Generic,
     Hashable,
     Iterable,
     Iterator,
     Mapping,
-    overload,
     Reversible,
     Sequence,
     Sized,
-    Type,
+)
+from contextlib import AbstractContextManager
+from typing import (
+    Any,
+    Callable,
+    Generic,
     TypeVar,
+    overload,
     type_check_only,
 )
 from typing_extensions import Protocol
@@ -37,7 +38,7 @@ _V = TypeVar('_V')
 _W = TypeVar('_W')
 _T_co = TypeVar('_T_co', covariant=True)
 _GenFn = TypeVar('_GenFn', bound=Callable[..., Iterator[Any]])
-_Raisable = BaseException | Type[BaseException]
+_Raisable = BaseException | type[BaseException]
 
 # The type of isinstance's second argument (from typeshed builtins)
 if sys.version_info >= (3, 10):
@@ -90,7 +91,7 @@ def consumer(func: _GenFn) -> _GenFn: ...
 def ilen(iterable: Iterable[_T]) -> int: ...
 def iterate(func: Callable[[_T], _T], start: _T) -> Iterator[_T]: ...
 def with_iter(
-    context_manager: ContextManager[Iterable[_T]],
+    context_manager: AbstractContextManager[Iterable[_T]],
 ) -> Iterator[_T]: ...
 def one(
     iterable: Iterable[_T],
@@ -415,7 +416,7 @@ class numeric_range(Generic[_T, _U], Sequence[_T], Hashable, Reversible[_T]):
     def __len__(self) -> int: ...
     def __reduce__(
         self,
-    ) -> tuple[Type[numeric_range[_T, _U]], tuple[_T, _T, _U]]: ...
+    ) -> tuple[type[numeric_range[_T, _U]], tuple[_T, _T, _U]]: ...
     def __repr__(self) -> str: ...
     def __reversed__(self) -> Iterator[_T]: ...
     def count(self, value: _T) -> int: ...
@@ -572,12 +573,12 @@ def distinct_combinations(
 def filter_except(
     validator: Callable[[Any], object],
     iterable: Iterable[_T],
-    *exceptions: Type[BaseException],
+    *exceptions: type[BaseException],
 ) -> Iterator[_T]: ...
 def map_except(
     function: Callable[[Any], _U],
     iterable: Iterable[_T],
-    *exceptions: Type[BaseException],
+    *exceptions: type[BaseException],
 ) -> Iterator[_U]: ...
 def map_if(
     iterable: Iterable[Any],
@@ -622,7 +623,7 @@ class callback_iter(Generic[_T], Iterator[_T]):
     def __enter__(self) -> callback_iter[_T]: ...
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: types.TracebackType | None,
     ) -> bool | None: ...
@@ -802,7 +803,7 @@ def outer_product(
 ) -> Iterator[tuple[_V, ...]]: ...
 def iter_suppress(
     iterable: Iterable[_T],
-    *exceptions: Type[BaseException],
+    *exceptions: type[BaseException],
 ) -> Iterator[_T]: ...
 def filter_map(
     func: Callable[[_T], _V | None],

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     Any,
     Callable,
-    Iterable,
-    Iterator,
-    overload,
-    Sequence,
-    Type,
     TypeVar,
+    overload,
 )
 
 # Type and type variable definitions
@@ -69,13 +66,13 @@ def unique(
 @overload
 def iter_except(
     func: Callable[[], _T],
-    exception: Type[BaseException] | tuple[Type[BaseException], ...],
+    exception: type[BaseException] | tuple[type[BaseException], ...],
     first: None = ...,
 ) -> Iterator[_T]: ...
 @overload
 def iter_except(
     func: Callable[[], _T],
-    exception: Type[BaseException] | tuple[Type[BaseException], ...],
+    exception: type[BaseException] | tuple[type[BaseException], ...],
     first: Callable[[], _U],
 ) -> Iterator[_T | _U]: ...
 @overload

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -554,9 +554,9 @@ class DerangementsTests(TestCase):
         range_in = range(self.RANGE_NUM)
         actual = set(mi.derangements(range_in))
         expected = {
-                x
-                for x in permutations(range_in)
-                if not any(x[i] == i for i in range_in)
+            x
+            for x in permutations(range_in)
+            if not any(x[i] == i for i in range_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -564,9 +564,9 @@ class DerangementsTests(TestCase):
         list_in = list(range(self.RANGE_NUM))
         actual = set(mi.derangements(list_in))
         expected = {
-                x
-                for x in permutations(list_in)
-                if not any(x[i] == i for i in list_in)
+            x
+            for x in permutations(list_in)
+            if not any(x[i] == i for i in list_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -574,9 +574,9 @@ class DerangementsTests(TestCase):
         tuple_in = tuple(range(self.RANGE_NUM))
         actual = set(mi.derangements(tuple_in))
         expected = {
-                x
-                for x in permutations(tuple_in)
-                if not any(x[i] == i for i in tuple_in)
+            x
+            for x in permutations(tuple_in)
+            if not any(x[i] == i for i in tuple_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -584,9 +584,9 @@ class DerangementsTests(TestCase):
         set_in = set(range(self.RANGE_NUM))
         actual = set(mi.derangements(set_in))
         expected = {
-                x
-                for x in permutations(set_in)
-                if not any(x[i] == i for i in range(self.RANGE_NUM))
+            x
+            for x in permutations(set_in)
+            if not any(x[i] == i for i in range(self.RANGE_NUM))
         }
         self.assertSetEqual(actual, expected)
 
@@ -594,9 +594,9 @@ class DerangementsTests(TestCase):
         list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
         actual = set(mi.derangements(list_in))
         expected = {
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
+            x
+            for x in permutations(list_in)
+            if not any(k == i for i, k in enumerate(x))
         }
         self.assertSetEqual(actual, expected)
 
@@ -644,9 +644,9 @@ class DerangementsTests(TestCase):
         list_in = [True, 1, 0, False]
         actual = set(mi.derangements(list_in))
         expected = {
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
+            x
+            for x in permutations(list_in)
+            if not any(k == i for i, k in enumerate(x))
         }
         self.assertSetEqual(actual, expected)
 
@@ -695,9 +695,9 @@ class DistinctDerangementsTests(TestCase):
         range_in = range(self.RANGE_NUM)
         actual = set(mi.distinct_derangements(range_in))
         expected = {
-                x
-                for x in permutations(range_in)
-                if not any(x[i] == i for i in range_in)
+            x
+            for x in permutations(range_in)
+            if not any(x[i] == i for i in range_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -705,9 +705,9 @@ class DistinctDerangementsTests(TestCase):
         list_in = list(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(list_in))
         expected = {
-                x
-                for x in permutations(list_in)
-                if not any(x[i] == i for i in list_in)
+            x
+            for x in permutations(list_in)
+            if not any(x[i] == i for i in list_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -715,9 +715,9 @@ class DistinctDerangementsTests(TestCase):
         tuple_in = tuple(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(tuple_in))
         expected = {
-                x
-                for x in permutations(tuple_in)
-                if not any(x[i] == i for i in tuple_in)
+            x
+            for x in permutations(tuple_in)
+            if not any(x[i] == i for i in tuple_in)
         }
         self.assertSetEqual(actual, expected)
 
@@ -725,9 +725,9 @@ class DistinctDerangementsTests(TestCase):
         set_in = set(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(set_in))
         expected = {
-                x
-                for x in permutations(set_in)
-                if not any(x[i] == i for i in range(self.RANGE_NUM))
+            x
+            for x in permutations(set_in)
+            if not any(x[i] == i for i in range(self.RANGE_NUM))
         }
         self.assertSetEqual(actual, expected)
 
@@ -735,9 +735,9 @@ class DistinctDerangementsTests(TestCase):
         list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
         actual = set(mi.distinct_derangements(list_in))
         expected = {
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
+            x
+            for x in permutations(list_in)
+            if not any(k == i for i, k in enumerate(x))
         }
         self.assertSetEqual(actual, expected)
 
@@ -746,9 +746,9 @@ class DistinctDerangementsTests(TestCase):
         actual = sorted(mi.distinct_derangements(list_in))
         expected = sorted(
             {
-                    x
-                    for x in permutations(list_in)
-                    if not any(k == i for i, k in enumerate(x))
+                x
+                for x in permutations(list_in)
+                if not any(k == i for i, k in enumerate(x))
             }
         )
         self.assertListEqual(actual, expected)
@@ -779,9 +779,9 @@ class DistinctDerangementsTests(TestCase):
         list_in = [True, 1, 0, False]
         actual = set(mi.distinct_derangements(list_in))
         expected = {
-                x
-                for x in mi.distinct_permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
+            x
+            for x in mi.distinct_permutations(list_in)
+            if not any(k == i for i, k in enumerate(x))
         }
         self.assertSetEqual(actual, expected)
 
@@ -2844,6 +2844,8 @@ class NumericRangeTests(TestCase):
                 'numeric_range expected at most 3 arguments, got 4',
             ),
         ]:
+            print(f"LATA = {args} -> {message}")
+            # print(f"ANS = {mi.numeric_range(*args)}")
             with self.assertRaisesRegex(TypeError, message):
                 mi.numeric_range(*args)
 
@@ -4122,7 +4124,7 @@ class _FrozenMultiset(Set):
         return hash(self._collection)
 
     def __repr__(self):
-        return "FrozenSet([{}]".format(", ".join(repr(x) for x in iter(self)))
+        return f'FrozenSet([{", ".join(repr(x) for x in iter(self))}]'
 
 
 class SetPartitionsTests(TestCase):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2844,8 +2844,6 @@ class NumericRangeTests(TestCase):
                 'numeric_range expected at most 3 arguments, got 4',
             ),
         ]:
-            print(f"LATA = {args} -> {message}")
-            # print(f"ANS = {mi.numeric_range(*args)}")
             with self.assertRaisesRegex(TypeError, message):
                 mi.numeric_range(*args)
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -553,61 +553,51 @@ class DerangementsTests(TestCase):
     def test_range(self):
         range_in = range(self.RANGE_NUM)
         actual = set(mi.derangements(range_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(range_in)
                 if not any(x[i] == i for i in range_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_range(self):
         list_in = list(range(self.RANGE_NUM))
         actual = set(mi.derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(list_in)
                 if not any(x[i] == i for i in list_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_tuple_range(self):
         tuple_in = tuple(range(self.RANGE_NUM))
         actual = set(mi.derangements(tuple_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(tuple_in)
                 if not any(x[i] == i for i in tuple_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_set_range(self):
         set_in = set(range(self.RANGE_NUM))
         actual = set(mi.derangements(set_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(set_in)
                 if not any(x[i] == i for i in range(self.RANGE_NUM))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_ints_non_duplicated(self):
         list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
         actual = set(mi.derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(list_in)
                 if not any(k == i for i, k in enumerate(x))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_ints_duplicated(self):
@@ -653,13 +643,11 @@ class DerangementsTests(TestCase):
     def test_boolean_equivalence(self):
         list_in = [True, 1, 0, False]
         actual = set(mi.derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(list_in)
                 if not any(k == i for i, k in enumerate(x))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_r(self):
@@ -706,74 +694,62 @@ class DistinctDerangementsTests(TestCase):
     def test_range(self):
         range_in = range(self.RANGE_NUM)
         actual = set(mi.distinct_derangements(range_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(range_in)
                 if not any(x[i] == i for i in range_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_range(self):
         list_in = list(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(list_in)
                 if not any(x[i] == i for i in list_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_tuple_range(self):
         tuple_in = tuple(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(tuple_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(tuple_in)
                 if not any(x[i] == i for i in tuple_in)
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_set_range(self):
         set_in = set(range(self.RANGE_NUM))
         actual = set(mi.distinct_derangements(set_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(set_in)
                 if not any(x[i] == i for i in range(self.RANGE_NUM))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_ints_non_duplicated(self):
         list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
         actual = set(mi.distinct_derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in permutations(list_in)
                 if not any(k == i for i, k in enumerate(x))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_list_ints_duplicated(self):
         list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
         actual = sorted(mi.distinct_derangements(list_in))
         expected = sorted(
-            set(
-                [
+            {
                     x
                     for x in permutations(list_in)
                     if not any(k == i for i, k in enumerate(x))
-                ]
-            )
+            }
         )
         self.assertListEqual(actual, expected)
 
@@ -802,13 +778,11 @@ class DistinctDerangementsTests(TestCase):
     def test_boolean_equivalence(self):
         list_in = [True, 1, 0, False]
         actual = set(mi.distinct_derangements(list_in))
-        expected = set(
-            [
+        expected = {
                 x
                 for x in mi.distinct_permutations(list_in)
                 if not any(k == i for i, k in enumerate(x))
-            ]
-        )
+        }
         self.assertSetEqual(actual, expected)
 
     def test_r(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}
+envlist = py{39,310,311,312,313}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This PR supports the PR #934 . The code base got passed through `pyupgrade --py39-plus ...` and embraces some changes from the #934 in order to unburden the latter.