### PR TITLE
Fix bug in sample() with the strict option with counts

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3809,8 +3809,6 @@ def _sample_counted(population, k, counts, strict):
         reservoir = []
         for _ in range(k):
             reservoir.append(feed(0))
-        if strict and len(reservoir) < k:
-            raise ValueError('Sample larger than population')
 
         W = 1.0
         while True:
@@ -3819,6 +3817,8 @@ def _sample_counted(population, k, counts, strict):
             element = feed(skip)
             reservoir[randrange(k)] = element
 
+    if strict and len(reservoir) < k:
+        raise ValueError('Sample larger than population')
     shuffle(reservoir)
     return reservoir
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3810,6 +3810,10 @@ def _sample_counted(population, k, counts, strict):
         for _ in range(k):
             reservoir.append(feed(0))
 
+    if strict and len(reservoir) < k:
+        raise ValueError('Sample larger than population')
+
+    with suppress(StopIteration):
         W = 1.0
         while True:
             W *= exp(log(random()) / k)
@@ -3817,8 +3821,6 @@ def _sample_counted(population, k, counts, strict):
             element = feed(skip)
             reservoir[randrange(k)] = element
 
-    if strict and len(reservoir) < k:
-        raise ValueError('Sample larger than population')
     shuffle(reservoir)
     return reservoir
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4637,15 +4637,17 @@ class SampleTests(TestCase):
 
         # weights and counts are mutally exclusive
         with self.assertRaises(TypeError):
-            mi.sample('abcde', 3, weights=[1,2,3,4,5], counts=[1,2,3,4,5])
+            mi.sample(
+                'abcde', 3, weights=[1, 2, 3, 4, 5], counts=[1, 2, 3, 4, 5]
+            )
 
         # Weighted sample larger than population
         with self.assertRaises(ValueError):
-            mi.sample('abcde', 10, weights=[1,2,3,4,5], strict=True)
+            mi.sample('abcde', 10, weights=[1, 2, 3, 4, 5], strict=True)
 
         # Counted sample larger than population
         with self.assertRaises(ValueError):
-            mi.sample('abcde', 10, counts=[1,1,1,1,1], strict=True)
+            mi.sample('abcde', 10, counts=[1, 1, 1, 1, 1], strict=True)
 
 
 class BarelySortable:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4633,6 +4633,20 @@ class SampleTests(TestCase):
         # The observed largest difference in 10,000 simulations was 4.337999
         self.assertTrue(difference_in_means < 4.4)
 
+    def test_error_cases(self):
+
+        # weights and counts are mutally exclusive
+        with self.assertRaises(TypeError):
+            mi.sample('abcde', 3, weights=[1,2,3,4,5], counts=[1,2,3,4,5])
+
+        # Weighted sample larger than population
+        with self.assertRaises(ValueError):
+            mi.sample('abcde', 10, weights=[1,2,3,4,5], strict=True)
+
+        # Counted sample larger than population
+        with self.assertRaises(ValueError):
+            mi.sample('abcde', 10, counts=[1,1,1,1,1], strict=True)
+
 
 class BarelySortable:
     def __init__(self, value):


### PR DESCRIPTION
The `strict` test for `_sample_counted()` was being bypassed when `feed()` raised `StopIteration`.  The fix is to move the test outside of the `suppress` context manager.