### PR TITLE
Add minor ruff-oriented fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TARGET_DIRS := more_itertools tests
+
 .PHONY: all-checks
 all-checks: requirements coverage check docs package
 
@@ -8,18 +10,23 @@ requirements:
 
 .PHONY: check
 check:
-	ruff format --check .
-	ruff check more_itertools tests
+	ruff format --check ${TARGET_DIRS}
+	ruff check ${TARGET_DIRS}
 	stubtest more_itertools.more more_itertools.recipes
 
 .PHONY: format
 format:
-	ruff format .
+	ruff format ${TARGET_DIRS}
 
 .PHONY: coverage
 coverage:
 	coverage run --include="more_itertools/*.py" -m unittest
 	coverage report --show-missing --fail-under=99
+
+.PHONY: lint
+lint:
+	ruff format ${TARGET_DIRS}
+	ruff check --fix ${TARGET_DIRS}
 
 .PHONY: test
 test:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3312,8 +3312,8 @@ def set_partitions(iterable, k=None, min_size=None, max_size=None):
     ['a', 'b', 'c']
 
     """
-    L = list(iterable)
-    n = len(L)
+    lst = list(iterable)
+    n = len(lst)
     if k is not None:
         if k < 1:
             raise ValueError(
@@ -3334,10 +3334,10 @@ def set_partitions(iterable, k=None, min_size=None, max_size=None):
         elif n == k:
             yield [[s] for s in L]
         else:
-            e, *M = L
-            for p in set_partitions_helper(M, k - 1):
+            e, *m = L
+            for p in set_partitions_helper(m, k - 1):
                 yield [[e], *p]
-            for p in set_partitions_helper(M, k):
+            for p in set_partitions_helper(m, k):
                 for i in range(len(p)):
                     yield p[:i] + [[e] + p[i]] + p[i + 1 :]
 
@@ -3345,12 +3345,12 @@ def set_partitions(iterable, k=None, min_size=None, max_size=None):
         for k in range(1, n + 1):
             yield from filter(
                 lambda z: all(min_size <= len(bk) <= max_size for bk in z),
-                set_partitions_helper(L, k),
+                set_partitions_helper(lst, k),
             )
     else:
         yield from filter(
             lambda z: all(min_size <= len(bk) <= max_size for bk in z),
-            set_partitions_helper(L, k),
+            set_partitions_helper(lst, k),
         )
 
 
@@ -3649,12 +3649,12 @@ def _sample_unweighted(iterator, k, strict):
     reservoir = list(islice(iterator, k))
     if strict and len(reservoir) < k:
         raise ValueError('Sample larger than population')
-    W = 1.0
+    w = 1.0
 
     with suppress(StopIteration):
         while True:
-            W *= exp(log(random()) / k)
-            skip = floor(log(random()) / log1p(-W))
+            w *= exp(log(random()) / k)
+            skip = floor(log(random()) / log1p(-w))
             element = next(islice(iterator, skip, None))
             reservoir[randrange(k)] = element
 
@@ -3725,10 +3725,10 @@ def _sample_counted(population, k, counts, strict):
         raise ValueError('Sample larger than population')
 
     with suppress(StopIteration):
-        W = 1.0
+        w = 1.0
         while True:
-            W *= exp(log(random()) / k)
-            skip = floor(log(random()) / log1p(-W))
+            w *= exp(log(random()) / k)
+            skip = floor(log(random()) / log1p(-w))
             element = feed(skip)
             reservoir[randrange(k)] = element
 
@@ -4932,10 +4932,10 @@ def dft(xarr):
 
     See :func:`idft` for the inverse Discrete Fourier Transform.
     """
-    N = len(xarr)
-    roots_of_unity = [e ** (n / N * tau * -1j) for n in range(N)]
-    for k in range(N):
-        coeffs = [roots_of_unity[k * n % N] for n in range(N)]
+    l = len(xarr)
+    roots_of_unity = [e ** (n / l * tau * -1j) for n in range(l)]
+    for k in range(l):
+        coeffs = [roots_of_unity[k * m % l] for m in range(l)]
         yield _complex_sumprod(xarr, coeffs)
 
 
@@ -4952,11 +4952,11 @@ def idft(Xarr):
 
     See :func:`dft` for the Discrete Fourier Transform.
     """
-    N = len(Xarr)
-    roots_of_unity = [e ** (n / N * tau * 1j) for n in range(N)]
-    for k in range(N):
-        coeffs = [roots_of_unity[k * n % N] for n in range(N)]
-        yield _complex_sumprod(Xarr, coeffs) / N
+    l = len(Xarr)
+    roots_of_unity = [e ** (n / l * tau * 1j) for n in range(l)]
+    for k in range(l):
+        coeffs = [roots_of_unity[k * m % l] for m in range(l)]
+        yield _complex_sumprod(Xarr, coeffs) / l
 
 
 def doublestarmap(func, iterable):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2154,6 +2154,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
 
     def __init__(self, *args):
         argc = len(args)
+        cls_name = self.__class__.__name__
         if argc == 1:
             (self._stop,) = args
             self._start = type(self._stop)(0)
@@ -2165,16 +2166,16 @@ class numeric_range(abc.Sequence, abc.Hashable):
             self._start, self._stop, self._step = args
         elif argc == 0:
             raise TypeError(
-                f'numeric_range expected at least 1 argument, got {argc}'
+                f'{cls_name} expected at least 1 argument, got {argc}'
             )
         else:
             raise TypeError(
-                f'numeric_range expected at most 3 arguments, got {argc}'
+                f'{cls_name} expected at most 3 arguments, got {argc}'
             )
 
         self._zero = type(self._step)(0)
         if self._step == self._zero:
-            raise ValueError('numeric_range() arg 3 must not be zero')
+            raise ValueError('{cls_name}() arg 3 must not be zero')
         self._growing = self._step > self._zero
 
     def __bool__(self):
@@ -2272,11 +2273,10 @@ class numeric_range(abc.Sequence, abc.Hashable):
         return numeric_range, (self._start, self._stop, self._step)
 
     def __repr__(self):
+        cls_name = self.__class__.__name__
         if self._step == 1:
-            return f"numeric_range({self._start!r}, {self._stop!r})"
-        return (
-            f"numeric_range({self._start!r}, {self._stop!r}, {self._step!r})"
-        )
+            return f"{cls_name}({self._start!r}, {self._stop!r})"
+        return f"{cls_name}({self._start!r}, {self._stop!r}, {self._step!r})"
 
     def __reversed__(self):
         return iter(

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2150,7 +2150,7 @@ class numeric_range(abc.Sequence, abc.Hashable):
 
     """
 
-    _EMPTY_HASH = hash(range(0, 0))
+    _EMPTY_HASH = hash(range(0))
 
     def __init__(self, *args):
         argc = len(args)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -794,7 +794,6 @@ def distinct_permutations(iterable, r=None):
     if r is None:
         r = size
 
-    # functools.partial(_partial, ... )
     algorithm = _full if (r == size) else partial(_partial, r=r)
 
     if 0 < r <= size:
@@ -1211,7 +1210,7 @@ def interleave_evenly(iterables, lengths=None):
         errors = [e - delta for e, delta in zip(errors, deltas_secondary)]
 
         # those iterables for which the error is negative are yielded
-        # ("diagonal step" in Bresenham)
+        # ("diagonal step" in Bresenham)  # noqa: ERA001
         for i, e_ in enumerate(errors):
             if e_ < 0:
                 yield next(iters_secondary[i])
@@ -1896,7 +1895,7 @@ def unzip(iterable):
                 return obj[i]
             except IndexError:
                 # basically if we have an iterable like
-                # iter([(1, 2, 3), (4, 5), (6,)])
+                # iter([(1, 2, 3), (4, 5), (6,)])  # noqa: ERA001
                 # the second unzipped iterable would fail at the third tuple
                 # since it would try to access tup[1]
                 # same with the third unzipped iterable and the second tuple

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,7 +1,6 @@
 import math
 import warnings
-
-from collections import Counter, defaultdict, deque, abc
+from collections import Counter, abc, defaultdict, deque
 from collections.abc import Sequence
 from contextlib import suppress
 from functools import cached_property, partial, reduce, wraps
@@ -15,24 +14,26 @@ from itertools import (
     dropwhile,
     groupby,
     islice,
+    product,
     repeat,
     starmap,
     takewhile,
     tee,
     zip_longest,
-    product,
 )
 from math import comb, e, exp, factorial, floor, fsum, log, log1p, perm, tau
+from operator import gt, itemgetter, lt, mul, sub
 from queue import Empty, Queue
 from random import random, randrange, shuffle, uniform
-from operator import itemgetter, mul, sub, gt, lt
 from sys import hexversion, maxsize
 from time import monotonic
 
 from .recipes import (
+    UnequalIterablesError,
     _marker,
     _zip_equal,
-    UnequalIterablesError,
+    all_equal,
+    batched,
     consume,
     flatten,
     nth,
@@ -40,8 +41,6 @@ from .recipes import (
     sieve,
     take,
     unique_everseen,
-    all_equal,
-    batched,
 )
 
 __all__ = [

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import types
-
 from collections.abc import (
     Container,
     Hashable,
@@ -24,6 +23,7 @@ from typing import (
     overload,
     type_check_only,
 )
+
 from typing_extensions import Protocol
 
 __all__ = [

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -10,7 +10,6 @@ Some backward-compatible usability improvements have been made.
 
 import math
 import operator
-
 from collections import deque
 from collections.abc import Sized
 from functools import lru_cache, partial
@@ -28,7 +27,7 @@ from itertools import (
     tee,
     zip_longest,
 )
-from random import randrange, sample, choice
+from random import choice, randrange, sample
 from sys import hexversion
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,16 @@ select = [
     "E",  # pycodestyle
     "F",  # pyflakes
     "I",  # isort
+    "N",  # pep8-naming
+    "UP",  # pyupgrade
 ]
-ignore = ["E731", "E741"]
+ignore = [
+    "E731",
+    "E741",
+    "N801",  # CapWords convention
+    "N802",  # function name should be lowercase
+    "N803",  # argument name should be lowercase
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ select = [
     "ERA",  # eradicate
     "F",  # pyflakes
     "I",  # isort
+    "ICN",  # flake8-import-conventions
     "N",  # pep8-naming
     "UP",  # pyupgrade
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ select = [
     "F",  # pyflakes
     "I",  # isort
     "ICN",  # flake8-import-conventions
+    "ISC",  # flake8-implicit-str-concat
     "N",  # pep8-naming
     "UP",  # pyupgrade
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ quote-style = "preserve"
 
 [tool.ruff.lint]
 select = [
+    "A",  # flake8-builtins
     "E",  # pycodestyle
     "ERA",  # eradicate
     "F",  # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ select = [
     "UP",  # pyupgrade
 ]
 ignore = [
-    "E731",
-    "E741",
+    "E731",  # lambda-assignment
+    "E741",  # ambiguous-variable-name
     "N801",  # CapWords convention
     "N802",  # function name should be lowercase
     "N803",  # argument name should be lowercase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ target-version = "py39"
 quote-style = "preserve"
 
 [tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+]
 ignore = ["E731", "E741"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ quote-style = "preserve"
 [tool.ruff.lint]
 select = [
     "E",  # pycodestyle
+    "ERA",  # eradicate
     "F",  # pyflakes
     "I",  # isort
     "N",  # pep8-naming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ select = [
     "ISC",  # flake8-implicit-str-concat
     "N",  # pep8-naming
     "PIE",  # flake8-pie
+    "T20",  # flake8-(p)print
     "UP",  # pyupgrade
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ select = [
     "ICN",  # flake8-import-conventions
     "ISC",  # flake8-implicit-str-concat
     "N",  # pep8-naming
+    "PIE",  # flake8-pie
     "UP",  # pyupgrade
 ]
 ignore = [

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2810,8 +2810,8 @@ class NumericRangeTests(TestCase):
             ((1.0, 7.0, 1.5), hash((1.0, 5.5, 1.5))),
             ((1.0, 7.5, 1.5), hash((1.0, 7.0, 1.5))),
             ((1.0, 1.5, 1.5), hash((1.0, 1.0, 1.5))),
-            ((1.5, 1.0, 1.5), hash(range(0, 0))),
-            ((1.5, 1.5, 1.5), hash(range(0, 0))),
+            ((1.5, 1.0, 1.5), hash(range(0))),
+            ((1.5, 1.5, 1.5), hash(range(0))),
             (
                 (Decimal("1.0"), Decimal("9.0"), Decimal("1.5")),
                 hash((Decimal("1.0"), Decimal("8.5"), Decimal("1.5"))),

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5396,59 +5396,59 @@ class ClassifyUniqueTests(TestCase):
         )
 
     def test_vs_unique_everseen(self):
-        input = 'AAAABBBBCCDAABBB'
-        output = [e for e, j, u in mi.classify_unique(input) if u]
+        input_ = 'AAAABBBBCCDAABBB'
+        output = [e for e, j, u in mi.classify_unique(input_) if u]
         self.assertEqual(output, ['A', 'B', 'C', 'D'])
-        self.assertEqual(list(mi.unique_everseen(input)), output)
+        self.assertEqual(list(mi.unique_everseen(input_)), output)
 
     def test_vs_unique_everseen_key(self):
-        input = 'aAbACCc'
-        output = [e for e, j, u in mi.classify_unique(input, str.lower) if u]
+        input_ = 'aAbACCc'
+        output = [e for e, j, u in mi.classify_unique(input_, str.lower) if u]
         self.assertEqual(output, list('abC'))
-        self.assertEqual(list(mi.unique_everseen(input, str.lower)), output)
+        self.assertEqual(list(mi.unique_everseen(input_, str.lower)), output)
 
     def test_vs_unique_justseen(self):
-        input = 'AAAABBBCCDABB'
-        output = [e for e, j, u in mi.classify_unique(input) if j]
+        input_ = 'AAAABBBCCDABB'
+        output = [e for e, j, u in mi.classify_unique(input_) if j]
         self.assertEqual(output, list('ABCDAB'))
-        self.assertEqual(list(mi.unique_justseen(input)), output)
+        self.assertEqual(list(mi.unique_justseen(input_)), output)
 
     def test_vs_unique_justseen_key(self):
-        input = 'AABCcAD'
-        output = [e for e, j, u in mi.classify_unique(input, str.lower) if j]
+        input_ = 'AABCcAD'
+        output = [e for e, j, u in mi.classify_unique(input_, str.lower) if j]
         self.assertEqual(output, list('ABCAD'))
-        self.assertEqual(list(mi.unique_justseen(input, str.lower)), output)
+        self.assertEqual(list(mi.unique_justseen(input_, str.lower)), output)
 
     def test_vs_duplicates_everseen(self):
-        input = [1, 2, 1, 2]
-        output = [e for e, j, u in mi.classify_unique(input) if not u]
+        input_ = [1, 2, 1, 2]
+        output = [e for e, j, u in mi.classify_unique(input_) if not u]
         self.assertEqual(output, [1, 2])
-        self.assertEqual(list(mi.duplicates_everseen(input)), output)
+        self.assertEqual(list(mi.duplicates_everseen(input_)), output)
 
     def test_vs_duplicates_everseen_key(self):
-        input = 'HEheHEhe'
+        input_ = 'HEheHEhe'
         output = [
-            e for e, j, u in mi.classify_unique(input, str.lower) if not u
+            e for e, j, u in mi.classify_unique(input_, str.lower) if not u
         ]
         self.assertEqual(output, list('heHEhe'))
         self.assertEqual(
-            list(mi.duplicates_everseen(input, str.lower)), output
+            list(mi.duplicates_everseen(input_, str.lower)), output
         )
 
     def test_vs_duplicates_justseen(self):
-        input = [1, 2, 3, 3, 2, 2]
-        output = [e for e, j, u in mi.classify_unique(input) if not j]
+        input_ = [1, 2, 3, 3, 2, 2]
+        output = [e for e, j, u in mi.classify_unique(input_) if not j]
         self.assertEqual(output, [3, 2])
-        self.assertEqual(list(mi.duplicates_justseen(input)), output)
+        self.assertEqual(list(mi.duplicates_justseen(input_)), output)
 
     def test_vs_duplicates_justseen_key(self):
-        input = 'HEheHHHhEheeEe'
+        input_ = 'HEheHHHhEheeEe'
         output = [
-            e for e, j, u in mi.classify_unique(input, str.lower) if not j
+            e for e, j, u in mi.classify_unique(input_, str.lower) if not j
         ]
         self.assertEqual(output, list('HHheEe'))
         self.assertEqual(
-            list(mi.duplicates_justseen(input, str.lower)), output
+            list(mi.duplicates_justseen(input_, str.lower)), output
         )
 
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,5 +1,4 @@
 import cmath
-
 from collections import Counter, abc
 from collections.abc import Set
 from datetime import datetime, timedelta
@@ -21,15 +20,15 @@ from itertools import (
     product,
     repeat,
 )
-from operator import add, mul, itemgetter
-from pickle import loads, dumps
+from operator import add, itemgetter, mul
+from pickle import dumps, loads
 from random import Random, random, randrange, seed
 from statistics import mean
 from string import ascii_letters
 from sys import version_info
 from time import sleep
 from traceback import format_exc
-from unittest import skipIf, TestCase
+from unittest import TestCase, skipIf
 
 import more_itertools as mi
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -582,10 +582,10 @@ class RandomProductTests(TestCase):
 
 
 class RandomPermutationTests(TestCase):
-    """Tests for ``random_permutation()``"""
+    """Tests for ``random_permutation()``."""
 
     def test_full_permutation(self):
-        """ensure every item from the iterable is returned in a new ordering
+        """Ensure every item from the iterable is returned in a new ordering.
 
         15 elements have a 1 in 1.3 * 10e12 of appearing in sorted order, so
         we fix a seed value just to be sure.
@@ -598,7 +598,7 @@ class RandomPermutationTests(TestCase):
             raise AssertionError("Values were not permuted")
 
     def test_partial_permutation(self):
-        """ensure all returned items are from the iterable, that the returned
+        """Ensure all returned items are from the iterable, that the returned
         permutation is of the desired length, and that all items eventually
         get returned.
 
@@ -621,11 +621,11 @@ class RandomPermutationTests(TestCase):
 
 
 class RandomCombinationTests(TestCase):
-    """Tests for ``random_combination()``"""
+    """Tests for ``random_combination()``."""
 
     def test_pseudorandomness(self):
-        """ensure different subsets of the iterable get returned over many
-        samplings of random combinations"""
+        """Ensure different subsets of the iterable get returned over many
+        samplings of random combinations."""
         items = range(15)
         all_items = set()
         for _ in range(50):
@@ -634,7 +634,7 @@ class RandomCombinationTests(TestCase):
         self.assertEqual(all_items, set(items))
 
     def test_no_replacement(self):
-        """ensure that elements are sampled without replacement"""
+        """Ensure that elements are sampled without replacement."""
         items = range(15)
         for _ in range(50):
             combination = mi.random_combination(items, len(items))
@@ -645,10 +645,10 @@ class RandomCombinationTests(TestCase):
 
 
 class RandomCombinationWithReplacementTests(TestCase):
-    """Tests for ``random_combination_with_replacement()``"""
+    """Tests for ``random_combination_with_replacement()``."""
 
     def test_replacement(self):
-        """ensure that elements are sampled with replacement"""
+        """Ensure that elements are sampled with replacement."""
         items = range(5)
         combo = mi.random_combination_with_replacement(items, len(items) * 2)
         self.assertEqual(2 * len(items), len(combo))
@@ -656,8 +656,8 @@ class RandomCombinationWithReplacementTests(TestCase):
             raise AssertionError("Combination contained no duplicates")
 
     def test_pseudorandomness(self):
-        """ensure different subsets of the iterable get returned over many
-        samplings of random combinations"""
+        """Ensure different subsets of the iterable get returned over many
+        samplings of random combinations."""
         items = range(15)
         all_items = set()
         for _ in range(50):

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -3,8 +3,8 @@ from doctest import DocTestSuite
 from fractions import Fraction
 from functools import reduce
 from itertools import combinations, count, groupby, permutations
-from operator import mul
 from math import comb, factorial
+from operator import mul
 from sys import version_info
 from unittest import TestCase, skipIf
 from unittest.mock import patch

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -164,7 +164,7 @@ class AllEqualTests(TestCase):
         next_count = 0
 
         class _groupby(groupby):
-            def __next__(true_self):
+            def __next__(self):
                 nonlocal next_count
                 next_count += 1
                 return super().__next__()
@@ -492,26 +492,28 @@ class IterExceptTests(TestCase):
     def test_multiple(self):
         """ensure can catch multiple exceptions"""
 
-        class Fiz(Exception):
+        class FizzError(Exception):
             pass
 
-        class Buzz(Exception):
+        class BuzzError(Exception):
             pass
 
         i = 0
 
-        def fizbuzz():
+        def fizzbuzz():
             nonlocal i
             i += 1
             if i % 3 == 0:
-                raise Fiz
+                raise FizzError
             if i % 5 == 0:
-                raise Buzz
+                raise BuzzError
             return i
 
         expected = ([1, 2], [4], [], [7, 8], [])
         for x in expected:
-            self.assertEqual(list(mi.iter_except(fizbuzz, (Fiz, Buzz))), x)
+            self.assertEqual(
+                list(mi.iter_except(fizzbuzz, (FizzError, BuzzError))), x
+            )
 
 
 class FirstTrueTests(TestCase):


### PR DESCRIPTION
Continues the following pull requests:

- #947 (add ruff formatter and linter)

This PR aims the goals as:

- enrich the project configuration concerning `ruff` (https://docs.astral.sh/ruff/configuration/) - add as many rules as it seems enough for this PR;
- add more `ruff` rules (the default set is `select = ["E4", "E7", "E9", "F"]` - not sufficient IMO);
- lint the code according to these rules (this may not exclude the refactoring which is not induced by ruff);
- keep this PR as small as possible.
