### PR TITLE
Clean up one() and fix over-specified test

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -556,27 +556,16 @@ def one(iterable, too_short=None, too_long=None):
     contents less destructively.
 
     """
-    it = iter(iterable)
-
-    try:
-        first_value = next(it)
-    except StopIteration as exc:
-        raise (
-            too_short or ValueError('too few items in iterable (expected 1)')
-        ) from exc
-
-    try:
-        second_value = next(it)
-    except StopIteration:
-        pass
-    else:
-        msg = (
-            f'Expected exactly one item in iterable, but got {first_value!r}, '
-            f'{second_value!r}, and perhaps more.'
-        )
-        raise too_long or ValueError(msg)
-
-    return first_value
+    iterator = iter(iterable)
+    for first in iterator:
+        for second in iterator:
+            msg = (
+                f'Expected exactly one item in iterable, but got {first!r}, '
+                f'{second!r}, and perhaps more.'
+            )
+            raise too_long or ValueError(msg)
+        return first
+    raise too_short or ValueError('too few items in iterable (expected 1)')
 
 
 def raise_(exception, *args):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -28,7 +28,6 @@ from statistics import mean
 from string import ascii_letters
 from sys import version_info
 from time import sleep
-from traceback import format_exc
 from unittest import skipIf, TestCase
 
 import more_itertools as mi
@@ -614,24 +613,12 @@ class OneTests(TestCase):
         it = iter(['item'])
         self.assertEqual(mi.one(it), 'item')
 
-    def test_too_short(self):
+    def test_too_short_new(self):
         it = iter([])
-        for too_short, exc_type in [
-            (None, ValueError),
-            (IndexError, IndexError),
-        ]:
-            with self.subTest(too_short=too_short):
-                try:
-                    mi.one(it, too_short=too_short)
-                except exc_type:
-                    formatted_exc = format_exc()
-                    self.assertIn('StopIteration', formatted_exc)
-                    self.assertIn(
-                        'The above exception was the direct cause',
-                        formatted_exc,
-                    )
-                else:
-                    self.fail()
+        self.assertRaises(ValueError, lambda: mi.one(it))
+        self.assertRaises(
+            OverflowError, lambda: mi.one(it, too_short=OverflowError)
+        )
 
     def test_too_long(self):
         it = count()


### PR DESCRIPTION
Clean-up and speed-up `one()` by using the same approach as `all_equal()` which differs only in that it returns `True` or `False` instead of raising an exception.

