### PR TITLE
Memory friendly version of exactly_n()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2971,7 +2971,7 @@ def exactly_n(iterable, n, predicate=bool):
     so avoid calling it on infinite iterables.
 
     """
-    return len(take(n + 1, filter(predicate, iterable))) == n
+    return ilen(islice(filter(predicate, iterable), n + 1)) == n
 
 
 def circular_shifts(iterable, steps=1):


### PR DESCRIPTION
Replace `len(take(...))` logic with `ilen(islice(...))` logic to save memory for the temporary list.