### PR TITLE
Improve iterate()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -489,12 +489,10 @@ def iterate(func, start):
     [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 
     """
-    while True:
-        yield start
-        try:
+    with suppress(StopIteration):
+        while True:
+            yield start
             start = func(start)
-        except StopIteration:
-            break
 
 
 def with_iter(context_manager):


### PR DESCRIPTION
* Hoist exception handling outside of the main loop.
* Replace `try/except break` logic with `contextlib.suppress`.

The result is short, sweet, and easy on the eyes.