### PR TITLE
Remove unnecessary indirections through yield-from

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1086,7 +1086,7 @@ class bucket:
             if self._validator(item_value):
                 self._cache[item_value].append(item)
 
-        yield from self._cache.keys()
+        return iter(self._cache)
 
     def __getitem__(self, value):
         if not self._validator(value):
@@ -4891,8 +4891,10 @@ def powerset_of_sets(iterable):
     of hash operations performed.
     """
     sets = tuple(map(set, dict.fromkeys(map(frozenset, zip(iterable)))))
-    for r in range(len(sets) + 1):
-        yield from starmap(set().union, combinations(sets, r))
+    return chain.from_iterable(
+        starmap(set().union, combinations(sets, r))
+        for r in range(len(sets) + 1)
+    )
 
 
 def join_mappings(**field_to_map):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -144,9 +144,9 @@ def tail(n, iterable):
     # either islice or deque will throw a TypeError. This is why we don't
     # check if it is Iterable.
     if isinstance(iterable, Sized):
-        yield from islice(iterable, max(0, len(iterable) - n), None)
+        return islice(iterable, max(0, len(iterable) - n), None)
     else:
-        yield from iter(deque(iterable, maxlen=n))
+        return iter(deque(iterable, maxlen=n))
 
 
 def consume(iterator, n=None):


### PR DESCRIPTION
Whenever there only a is single yield point not in a loop or with-statement, a `yield-from` adds unnecessary overhead and the iterator can be returned directly.