### PR TITLE
Remove unnecessary step in powerset_of_sets()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4890,7 +4890,7 @@ def powerset_of_sets(iterable):
     :func:`powerset_of_sets` takes care to minimize the number
     of hash operations performed.
     """
-    sets = tuple(map(set, dict.fromkeys(map(frozenset, zip(iterable)))))
+    sets = tuple(dict.fromkeys(map(frozenset, zip(iterable))))
     return chain.from_iterable(
         starmap(set().union, combinations(sets, r))
         for r in range(len(sets) + 1)


### PR DESCRIPTION
The conversion of frozensets to sets isn't needed.

This was an artifact of one of my early drafts before the `set().union` was incorporated.