### PR TITLE
Use the Furo documentation theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,5 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,15 +118,12 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 # html_theme_options = {}
-
-# Add any paths that contain custom themes here, relative to this directory.
-# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx
-sphinx_rtd_theme
+furo>=2024.8

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,6 +4,6 @@ mypy
 ruff
 setuptools
 sphinx
-sphinx_rtd_theme
+furo>=2024.8
 twine
 wheel


### PR DESCRIPTION
### Changes

This PR proposes adopting the Furo theme, recommended for documentation sites with a small number of pages. It is currently used for the Python Developer's guide, urllib3, pip, and many other projects.

Note: you may find it useful to enable [pull-request previews](https://docs.readthedocs.com/platform/stable/pull-requests.html) on Read the Docs, to have a 'live' preview of the documentation with this PR applied.

A