### PR TITLE
Fix `one` docstring example error

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -553,7 +553,7 @@ def one(iterable, too_short=None, too_long=None):
         >>> one(it)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
-        ValueError: too many items in iterable (expected 1)'
+        ValueError: too few items in iterable (expected 1)'
         >>> too_short = IndexError('too few items')
         >>> one(it, too_short=too_short)  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):


### PR DESCRIPTION
I noticed that the error message in this example is wrong.

```py
>>> from more_itertools import one
>>> it = []
>>> one(it)
Traceback (most recent call last):
  File "<REDACTED>/python3.13/site-packages/more_itertools/more.py", line 550, in one
    first_value = next(it)
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    one(it)
    ~~~^^^^
  File "<REDACTED>/python3.13/site-packages/more_itertools/more.py", line 552, in one
    raise (
        too_short or ValueError('too few items in iterable (expected 1)')
    ) from e
ValueError: too few items in iterable (expected 1)
```

I guess the docstring was overhauled way back in dfcd00a4e8449d01594e0b6bda5ae5ee702d7103 and this snuck in.