### PR TITLE
Use Python 3.13 for read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.13"
 
 sphinx:
    configuration: docs/conf.py


### PR DESCRIPTION
The latest RTD build failed: https://app.readthedocs.org/projects/more-itertools/builds/27750058/

Sorry for not noticing this, Python 3.8 is now end-of-life. This PR proposes using 3.13, the latest stable release, instead.

Follow-up to #968, cc @bbayles 

A