### PR TITLE
Remove setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
### Changes
The project uses `flit_core` as build backend. Including the `setup.py` file should not be necessary anymore.