### PR TITLE
Include `derangements` by itself

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -869,39 +869,12 @@ def derangements(iterable, r=None):
         [(2, 0), (2, 3), (3, 0)]
 
     Elements are treated as unique based on their position, not on their value.
-    If the input elements are unique, there will be no repeated values within a permutation.
+    If the input elements are unique, there will be no repeated values within a
+    permutation.
     """
-    pool = tuple(iterable)
-    xs = tuple(zip(pool))
+    xs = tuple(zip(iterable))
     for ys in permutations(xs, r=r):
-        if any(map(operator.eq, xs, ys)):
-            continue
-        yield tuple(y[0] for y in ys)
-
-
-def distinct_derangements(iterable, r=None):
-    """Yield successive distinct derangements of the elements in *iterable*.
-
-        >>> for d in distinct_derangements(['Alice', 'Bob', 'Carol', 'Alice']):
-        ...    print(', '.join(d))
-        Bob, Alice, Alice, Carol
-        Carol, Alice, Alice, Bob
-
-    Equivalent to yielding from ``set(derangements(iterable))``, except
-    duplicates are not generated and thrown away. For larger input sequences
-    this is more efficient.
-
-    If *r* is given, only the *r*-length derangements are yielded.
-
-        >>> sorted(distinct_derangements([0, 0, 1, 2], 3))
-        [(1, 2, 0), (2, 1, 0)]
-        >>> sorted(distinct_derangements([0, 0, 1, 2], 2))
-        [(1, 2), (2, 1)]
-    """
-    pool = tuple(iterable)
-    xs = tuple(zip(pool))
-    for ys in distinct_permutations(xs, r=r):
-        if any(map(operator.eq, xs, ys)):
+        if any(map(operator.is_, xs, ys)):
             continue
         yield tuple(y[0] for y in ys)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,5 +1,4 @@
 import math
-import operator
 import warnings
 
 from collections import Counter, defaultdict, deque, abc
@@ -27,7 +26,7 @@ from itertools import (
 from math import comb, e, exp, factorial, floor, fsum, log, log1p, perm, tau
 from queue import Empty, Queue
 from random import random, randrange, shuffle, uniform
-from operator import itemgetter, mul, sub, gt, lt
+from operator import is_ as operator_is, itemgetter, mul, sub, gt, lt
 from sys import hexversion, maxsize
 from time import monotonic
 
@@ -874,7 +873,7 @@ def derangements(iterable, r=None):
     """
     xs = tuple(zip(iterable))
     for ys in permutations(xs, r=r):
-        if any(map(operator.is_, xs, ys)):
+        if any(map(operator_is, xs, ys)):
             continue
         yield tuple(y[0] for y in ys)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -68,12 +68,9 @@ __all__ = [
     'count_cycle',
     'countable',
     'derangements',
-    'derangements_by_value',
     'dft',
     'difference',
     'distinct_combinations',
-    'distinct_derangements',
-    'distinct_derangements_by_value',
     'distinct_permutations',
     'distribute',
     'divide',
@@ -871,20 +868,8 @@ def derangements(iterable, r=None):
         >>> sorted(derangements([0, 2, 3], 2))
         [(2, 0), (2, 3), (3, 0)]
 
-    Note that in case of duplicates in input, these are treated as separate
-    entries with the same restriction in the derangements. For example:
-
-        >>> for d in derangements(['Alice', 'Bob', 'Carol', 'Alice']):
-        ...    print(', '.join(d))
-        Bob, Alice, Alice, Carol
-        Bob, Alice, Alice, Carol
-        Carol, Alice, Alice, Bob
-        Carol, Alice, Alice, Bob
-
-    Here Alice is excluded from both original positions of Alice, and also
-    the results are duplicated which is in line with how duplicates are
-    handled by ``itertools.permutations``. If deduplicated derangements
-    are needed, use ``distinct_derangements``.
+    Elements are treated as unique based on their position, not on their value.
+    If the input elements are unique, there will be no repeated values within a permutation.
     """
     pool = tuple(iterable)
     xs = tuple(zip(pool))
@@ -917,89 +902,6 @@ def distinct_derangements(iterable, r=None):
     xs = tuple(zip(pool))
     for ys in distinct_permutations(xs, r=r):
         if any(map(operator.eq, xs, ys)):
-            continue
-        yield tuple(y[0] for y in ys)
-
-
-def derangements_by_value(iterable, r=None):
-    """Yield successive derangements of the elements in *iterable* by value
-    of the elements.
-
-    A derangement by value is a permutation in which no element appears at
-    the index of its value. Suppose three classes 0, 1 and 2 should be
-    assigned to a different teacher than last year, one of which was
-    replaced by a new teacher. These teachers could be indicated by 0, 1
-    and 3, with 0 and 1 being the teachers that stayed and should get a
-    new class, whereas teacher 3 can get any class. Then, the options
-    to assign the classes to the teachers are:
-
-        >>> sorted(derangements_by_value([0, 1, 3]))
-        [(1, 0, 3), (1, 3, 0), (3, 0, 1)]
-
-    Contrast this to the index-based implementation which skips the outcome
-    in which classes 0 and 1 are swapped and the new teacher gets class 2:
-
-        >>> sorted(derangements([0, 1, 3]))
-        [(1, 3, 0), (3, 0, 1)]
-
-    If *r* is given, only the *r*-length derangements by value are yielded.
-
-        >>> sorted(derangements_by_value([0, 2, 3], 2))
-        [(2, 0), (2, 3), (3, 0), (3, 2)]
-
-    Note that in case of non-integer inputs, the result will be the same
-    as pure ``itertools.permutations``:
-
-        >>> for d in sorted(derangements_by_value(["A", "B", "C"])):
-        ...    print(', '.join(d))
-        A, B, C
-        A, C, B
-        B, A, C
-        B, C, A
-        C, A, B
-        C, B, A
-
-    Note that in case of duplicates in input, these lead to duplicated
-    results:
-
-        >>> sorted(derangements_by_value([0, 0, 1]))
-        [(1, 0, 0), (1, 0, 0)]
-
-    This is in line with how duplicates are handled by
-    ``itertools.permutations``. If deduplicated derangements by value3
-    are needed, use ``distinct_derangements_by_value``.
-    """
-    pool = tuple(iterable)
-    xs = tuple(zip(pool))
-    indices = tuple(zip(range(len(pool))))
-    for ys in permutations(xs, r=r):
-        if any(map(operator.eq, indices, ys)):
-            continue
-        yield tuple(y[0] for y in ys)
-
-
-def distinct_derangements_by_value(iterable, r=None):
-    """Yield successive distinct derangements of the elements in *iterable*
-    based on the value of the elements.
-
-        >>> sorted(distinct_derangements_by_value([0, 0, 1, 2]))
-        [(1, 0, 0, 2), (1, 2, 0, 0), (2, 0, 0, 1), (2, 0, 1, 0)]
-
-    Equivalent to yielding from ``set(derangements_by_value(iterable))``,
-    except duplicates are not generated and thrown away. For larger input
-    sequences this is more efficient.
-
-    If *r* is given, only the *r*-length derangements are yielded.
-
-        >>> sorted(distinct_derangements_by_value([0, 0, 1, 2], 2))
-        [(1, 0), (1, 2), (2, 0)]
-
-    """
-    pool = tuple(iterable)
-    xs = tuple(zip(pool))
-    indices = tuple(zip(range(len(pool))))
-    for ys in distinct_permutations(xs, r=r):
-        if any(map(operator.eq, indices, ys)):
             continue
         yield tuple(y[0] for y in ys)
 

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -48,12 +48,9 @@ __all__ = [
     'count_cycle',
     'countable',
     'derangements',
-    'derangements_by_value',
     'dft',
     'difference',
     'distinct_combinations',
-    'distinct_derangements',
-    'distinct_derangements_by_value',
     'distinct_permutations',
     'distribute',
     'divide',
@@ -227,15 +224,6 @@ def distinct_permutations(
     iterable: Iterable[_T], r: int | None = ...
 ) -> Iterator[tuple[_T, ...]]: ...
 def derangements(
-    iterable: Iterable[_T], r: int | None = None
-) -> Iterator[tuple[_T, ...]]: ...
-def distinct_derangements(
-    iterable: Iterable[_T], r: int | None = None
-) -> Iterator[tuple[_T, ...]]: ...
-def derangements_by_value(
-    iterable: Iterable[_T], r: int | None = None
-) -> Iterator[tuple[_T, ...]]: ...
-def distinct_derangements_by_value(
     iterable: Iterable[_T], r: int | None = None
 ) -> Iterator[tuple[_T, ...]]: ...
 def intersperse(

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -529,27 +529,7 @@ class DistinctPermutationsTests(TestCase):
 
 
 class DerangementsTests(TestCase):
-
     RANGE_NUM = 8
-
-    def test_range_manual(self):
-        range_in = range(4)
-        actual = sorted(mi.derangements(range_in))
-        expected = [
-            (1, 0, 3, 2),
-            (1, 2, 3, 0),
-            (1, 3, 0, 2),
-            (2, 0, 3, 1),
-            (2, 3, 0, 1),
-            (2, 3, 1, 0),
-            (3, 0, 1, 2),
-            (3, 2, 0, 1),
-            (3, 2, 1, 0),
-        ]
-        self.assertListEqual(actual, expected)
-
-        actual = sorted(mi.derangements_by_value(range_in))
-        self.assertListEqual(actual, expected)
 
     def test_range(self):
         range_in = range(self.RANGE_NUM)
@@ -561,9 +541,6 @@ class DerangementsTests(TestCase):
                 if not any(x[i] == i for i in range_in)
             ]
         )
-        self.assertSetEqual(actual, expected)
-
-        actual = set(mi.derangements_by_value(range_in))
         self.assertSetEqual(actual, expected)
 
     def test_list_range(self):
@@ -578,9 +555,6 @@ class DerangementsTests(TestCase):
         )
         self.assertSetEqual(actual, expected)
 
-        actual = set(mi.derangements_by_value(list_in))
-        self.assertSetEqual(actual, expected)
-
     def test_tuple_range(self):
         tuple_in = tuple(range(self.RANGE_NUM))
         actual = set(mi.derangements(tuple_in))
@@ -591,9 +565,6 @@ class DerangementsTests(TestCase):
                 if not any(x[i] == i for i in tuple_in)
             ]
         )
-        self.assertSetEqual(actual, expected)
-
-        actual = set(mi.derangements_by_value(tuple_in))
         self.assertSetEqual(actual, expected)
 
     def test_set_range(self):
@@ -608,21 +579,8 @@ class DerangementsTests(TestCase):
         )
         self.assertSetEqual(actual, expected)
 
-        actual = set(mi.derangements_by_value(set_in))
-        self.assertSetEqual(actual, expected)
-
     def test_list_ints_non_duplicated(self):
         list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
-        actual = set(mi.derangements_by_value(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
         actual = set(mi.derangements(list_in))
         expected = set(
             [
@@ -635,16 +593,6 @@ class DerangementsTests(TestCase):
 
     def test_list_ints_duplicated(self):
         list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
-        actual = list(mi.derangements_by_value(list_in))
-        expected = list(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
-            ]
-        )
-        self.assertListEqual(actual, expected)
-
         actual = list(mi.derangements(list_in))
         expected = list(
             [
@@ -661,10 +609,6 @@ class DerangementsTests(TestCase):
         compared = list(mi.derangements(set(list_in)))
         self.assertLess(len(compared), len(actual))
 
-        actual = list(mi.derangements_by_value(list_in))
-        compared = list(mi.derangements_by_value(set(list_in)))
-        self.assertLess(len(compared), len(actual))
-
     def test_list_unsortable(self):
         list_in = ['1', 2, 2, 3, 3, 3]
         actual = list(mi.derangements(list_in))
@@ -673,16 +617,6 @@ class DerangementsTests(TestCase):
                 x
                 for x in permutations(list_in)
                 if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertListEqual(actual, expected)
-
-        actual = list(mi.derangements_by_value(list_in))
-        expected = list(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
             ]
         )
         self.assertListEqual(actual, expected)
@@ -697,14 +631,6 @@ class DerangementsTests(TestCase):
         ]
         self.assertListEqual(actual, expected)
 
-        actual = list(mi.derangements_by_value(list_in))
-        expected = [
-            x
-            for x in permutations(list_in)
-            if not any(k == i for i, k in enumerate(x))
-        ]
-        self.assertListEqual(actual, expected)
-
     def test_boolean_equivalence(self):
         list_in = [True, 1, 0, False]
         actual = set(mi.derangements(list_in))
@@ -713,16 +639,6 @@ class DerangementsTests(TestCase):
                 x
                 for x in permutations(list_in)
                 if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        actual = set(mi.derangements_by_value(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
             ]
         )
         self.assertSetEqual(actual, expected)
@@ -755,271 +671,6 @@ class DerangementsTests(TestCase):
                     ]
                 )
                 actual = list(mi.derangements(iterable, r))
-                self.assertCountEqual(actual, expected)
-
-                expected = list(
-                    [
-                        x
-                        for x in permutations(iterable, r)
-                        if not any(x[i] == i for i in range(r))
-                    ]
-                )
-                actual = list(mi.derangements_by_value(iterable, r))
-                self.assertCountEqual(actual, expected)
-
-
-class DistinctDerangementsTests(TestCase):
-
-    RANGE_NUM = 8
-
-    def test_list_manual(self):
-        list_in = [0, 0, 1, 2]
-
-        # Derange by value
-        actual = sorted(mi.distinct_derangements_by_value(list_in))
-        expected = [(1, 0, 0, 2), (1, 2, 0, 0), (2, 0, 0, 1), (2, 0, 1, 0)]
-        self.assertListEqual(actual, expected)
-
-        # Derange by index
-        actual = sorted(mi.distinct_derangements(list_in))
-        expected = [(1, 2, 0, 0), (2, 1, 0, 0)]
-        self.assertListEqual(actual, expected)
-
-    def test_list_manual_string(self):
-        string_in = "ABAB"
-
-        # Derange by index: only flipped version meets criterion
-        actual = sorted(mi.distinct_derangements(string_in))
-        expected = [("B", "A", "B", "A")]
-        self.assertListEqual(actual, expected)
-
-        # Derange by value: no permutation dropped for characters
-        actual = sorted(mi.distinct_derangements_by_value(string_in))
-        expected = sorted(mi.distinct_permutations(string_in))
-        self.assertListEqual(actual, expected)
-
-    def test_range(self):
-        range_in = range(self.RANGE_NUM)
-
-        # Derange by value
-        actual = set(mi.distinct_derangements_by_value(range_in))
-        expected = set(
-            [
-                x
-                for x in permutations(range_in)
-                if not any(x[i] == i for i in range_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        # Derange by index - no difference for a range input
-        actual = set(mi.distinct_derangements(range_in))
-        self.assertSetEqual(actual, expected)
-
-    def test_list_range(self):
-        list_in = list(range(self.RANGE_NUM))
-
-        # Derange by value
-        actual = set(mi.distinct_derangements_by_value(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(x[i] == i for i in list_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        # Derange by index - no difference for a range input
-        actual = set(mi.distinct_derangements(list_in))
-        self.assertSetEqual(actual, expected)
-
-    def test_tuple_range(self):
-        tuple_in = tuple(range(self.RANGE_NUM))
-
-        # Derange by value
-        actual = set(mi.distinct_derangements_by_value(tuple_in))
-        expected = set(
-            [
-                x
-                for x in permutations(tuple_in)
-                if not any(x[i] == i for i in tuple_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        # Derange by index - no difference for a range input
-        actual = set(mi.distinct_derangements(tuple_in))
-        self.assertSetEqual(actual, expected)
-
-    def test_set_range(self):
-        set_in = set(range(self.RANGE_NUM))
-
-        # Derange by value
-        actual = set(mi.distinct_derangements_by_value(set_in))
-        expected = set(
-            [
-                x
-                for x in permutations(set_in)
-                if not any(x[i] == i for i in range(self.RANGE_NUM))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        # Derange by index - no difference for a range input
-        actual = set(mi.distinct_derangements(set_in))
-        self.assertSetEqual(actual, expected)
-
-    def test_list_ints_non_duplicated(self):
-        list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
-
-        # Derange by value
-        actual = set(mi.distinct_derangements_by_value(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        # Derange by index
-        actual = set(mi.distinct_derangements(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_list_ints_duplicated(self):
-        list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
-
-        # Derange by value
-        actual = sorted(mi.distinct_derangements_by_value(list_in))
-        expected = sorted(
-            set(
-                [
-                    x
-                    for x in permutations(list_in)
-                    if not any(k == i for i, k in enumerate(x))
-                ]
-            )
-        )
-        self.assertListEqual(actual, expected)
-
-        # Derange by index
-        actual = sorted(mi.distinct_derangements(list_in))
-        expected = sorted(
-            set(
-                [
-                    x
-                    for x in permutations(list_in)
-                    if not any(k == list_in[i] for i, k in enumerate(x))
-                ]
-            )
-        )
-        self.assertListEqual(actual, expected)
-
-    def test_list_ints_duplicated_lower_count(self):
-        list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
-        actual = list(mi.distinct_derangements(list_in))
-        compared = list(mi.derangements(list_in))
-        self.assertLess(len(actual), len(compared))
-        actual = list(mi.distinct_derangements_by_value(list_in))
-        compared = list(mi.derangements_by_value(list_in))
-        self.assertLess(len(actual), len(compared))
-
-    def test_list_unsortable(self):
-        list_in = ['1', 2, 2, 3, 3, 3]
-        actual = len(list(mi.distinct_derangements(list_in)))
-        compared = len(list(mi.derangements(list_in)))
-        self.assertLess(actual, compared)
-        actual = list(mi.distinct_derangements_by_value(list_in))
-        compared = list(mi.derangements_by_value(list_in))
-        self.assertLess(len(actual), len(compared))
-
-    def test_list_unhashable(self):
-        list_in = ([1], [1], 2)
-        actual = list(mi.distinct_derangements(list_in))
-        expected = [
-            x
-            for x in mi.distinct_permutations(list_in)
-            if not any(k == list_in[i] for i, k in enumerate(x))
-        ]
-        self.assertListEqual(actual, expected)
-
-        actual = list(mi.distinct_derangements_by_value(list_in))
-        expected = [
-            x
-            for x in mi.distinct_permutations(list_in)
-            if not any(k == i for i, k in enumerate(x))
-        ]
-        self.assertListEqual(actual, expected)
-
-    def test_boolean_equivalence(self):
-        list_in = [True, 1, 0, False]
-        actual = set(mi.distinct_derangements_by_value(list_in))
-        expected = set(
-            [
-                x
-                for x in mi.distinct_permutations(list_in)
-                if not any(k == i for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-        actual = set(mi.distinct_derangements(list_in))
-        expected = set(
-            [
-                x
-                for x in mi.distinct_permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_r(self):
-        for iterable, r in (
-            ('mississippi', 0),
-            ('mississippi', 1),
-            ('mississippi', 6),
-            ('mississippi', 7),
-            ('mississippi', 12),
-            ([0, 1, 1, 0], 0),
-            ([0, 1, 1, 0], 1),
-            ([0, 1, 1, 0], 2),
-            ([0, 1, 1, 0], 3),
-            ([0, 1, 1, 0], 4),
-            (['a'], 0),
-            (['a'], 1),
-            (['a'], 5),
-            ([], 0),
-            ([], 1),
-            ([], 4),
-        ):
-            with self.subTest(iterable=iterable, r=r):
-                expected = list(
-                    [
-                        x
-                        for x in mi.distinct_permutations(iterable, r)
-                        if not any(x[i] == i for i in range(r))
-                    ]
-                )
-                actual = list(mi.distinct_derangements_by_value(iterable, r))
-                self.assertCountEqual(actual, expected)
-
-                expected = list(
-                    [
-                        x
-                        for x in mi.distinct_permutations(iterable, r)
-                        if not any(k == iterable[i] for i, k in enumerate(x))
-                    ]
-                )
-                actual = list(mi.distinct_derangements(iterable, r))
                 self.assertCountEqual(actual, expected)
 
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -529,149 +529,85 @@ class DistinctPermutationsTests(TestCase):
 
 
 class DerangementsTests(TestCase):
-    RANGE_NUM = 8
-
-    def test_range(self):
-        range_in = range(self.RANGE_NUM)
-        actual = set(mi.derangements(range_in))
+    def test_unique_values(self):
+        n = 8
         expected = set(
-            [
-                x
-                for x in permutations(range_in)
-                if not any(x[i] == i for i in range_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_list_range(self):
-        list_in = list(range(self.RANGE_NUM))
-        actual = set(mi.derangements(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(x[i] == i for i in list_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_tuple_range(self):
-        tuple_in = tuple(range(self.RANGE_NUM))
-        actual = set(mi.derangements(tuple_in))
-        expected = set(
-            [
-                x
-                for x in permutations(tuple_in)
-                if not any(x[i] == i for i in tuple_in)
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_set_range(self):
-        set_in = set(range(self.RANGE_NUM))
-        actual = set(mi.derangements(set_in))
-        expected = set(
-            [
-                x
-                for x in permutations(set_in)
-                if not any(x[i] == i for i in range(self.RANGE_NUM))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_list_ints_non_duplicated(self):
-        list_in = list(mi.sieve(20))  # [2, 3, 5, 7, 11, 13, 17, 19]
-        actual = set(mi.derangements(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertSetEqual(actual, expected)
-
-    def test_list_ints_duplicated(self):
-        list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
-        actual = list(mi.derangements(list_in))
-        expected = list(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertListEqual(actual, expected)
-
-    def test_list_ints_duplicated_higher_count(self):
-        list_in = list(mi.factor(360))  # [2, 2, 2, 3, 3, 5]
-        actual = list(mi.derangements(list_in))
-        compared = list(mi.derangements(set(list_in)))
-        self.assertLess(len(compared), len(actual))
-
-    def test_list_unsortable(self):
-        list_in = ['1', 2, 2, 3, 3, 3]
-        actual = list(mi.derangements(list_in))
-        expected = list(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
-        )
-        self.assertListEqual(actual, expected)
-
-    def test_list_unhashable(self):
-        list_in = ([1], [1], 2)
-        actual = list(mi.derangements(list_in))
-        expected = [
             x
-            for x in permutations(list_in)
-            if not any(k == list_in[i] for i, k in enumerate(x))
-        ]
-        self.assertListEqual(actual, expected)
-
-    def test_boolean_equivalence(self):
-        list_in = [True, 1, 0, False]
-        actual = set(mi.derangements(list_in))
-        expected = set(
-            [
-                x
-                for x in permutations(list_in)
-                if not any(k == list_in[i] for i, k in enumerate(x))
-            ]
+            for x in permutations(range(n))
+            if not any(x[i] == i for i in range(n))
         )
-        self.assertSetEqual(actual, expected)
+        for i, iterable in enumerate(
+            [
+                range(n),
+                list(range(n)),
+                set(range(n)),
+            ]
+        ):
+            actual = set(mi.derangements(iterable))
+            self.assertEqual(actual, expected)
+
+    def test_repeated_values(self):
+        self.assertEqual(
+            [''.join(x) for x in mi.derangements('AACD')],
+            [
+                'AADC',
+                'ACDA',
+                'ADAC',
+                'CADA',
+                'CDAA',
+                'CDAA',
+                'DAAC',
+                'DCAA',
+                'DCAA',
+            ],
+        )
+
+    def test_unsortable_unhashable(self):
+        iterable = (0, True, ['Carol'])
+        actual = list(mi.derangements(iterable))
+        expected = [(True, ['Carol'], 0), (['Carol'], 0, True)]
+        self.assertListEqual(actual, expected)
 
     def test_r(self):
-        for iterable, r in (
-            ('mississippi', 0),
-            ('mississippi', 1),
-            ('mississippi', 6),
-            # ('mississippi', 7),
-            ('mississippi', 12),
-            ([0, 1, 1, 0], 0),
-            ([0, 1, 1, 0], 1),
-            ([0, 1, 1, 0], 2),
-            ([0, 1, 1, 0], 3),
-            ([0, 1, 1, 0], 4),
-            (['a'], 0),
-            (['a'], 1),
-            (['a'], 5),
-            ([], 0),
-            ([], 1),
-            ([], 4),
-        ):
-            with self.subTest(iterable=iterable, r=r):
-                expected = list(
-                    [
-                        x
-                        for x in permutations(iterable, r)
-                        if not any(iterable[i] == k for i, k in enumerate(x))
-                    ]
-                )
-                actual = list(mi.derangements(iterable, r))
-                self.assertCountEqual(actual, expected)
+        s = 'ABCD'
+        for r, expected in [
+            (0, ['']),
+            (1, ['B', 'C', 'D']),
+            (2, ['BA', 'BC', 'BD', 'CA', 'CD', 'DA', 'DC']),
+            (
+                3,
+                [
+                    'BAD',
+                    'BCA',
+                    'BCD',
+                    'BDA',
+                    'CAB',
+                    'CAD',
+                    'CDA',
+                    'CDB',
+                    'DAB',
+                    'DCA',
+                    'DCB',
+                ],
+            ),
+            (
+                4,
+                [
+                    'BADC',
+                    'BCDA',
+                    'BDAC',
+                    'CADB',
+                    'CDAB',
+                    'CDBA',
+                    'DABC',
+                    'DCAB',
+                    'DCBA',
+                ],
+            ),
+        ]:
+            with self.subTest(r=r):
+                actual = [''.join(x) for x in mi.derangements(s, r=r)]
+                self.assertEqual(actual, expected)
 
 
 class IlenTests(TestCase):


### PR DESCRIPTION
This PR grabs the commits from #946 and then drops the functions other than `derangements`. I'm still where I was when I made [this comment](https://github.com/more-itertools/more-itertools/issues/937#issuecomment-2587478939), and I think that function would be a nice addition to the library.

@debruijn, are you OK with this? The other function implementations are good, but I think this is the core.