### PR TITLE
Improve islice_extended memory usage when start<0 and step>0

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2631,8 +2631,10 @@ def _islice_helper(it, s):
             if n <= 0:
                 return
 
-            for index, item in islice(cache, 0, n, step):
-                yield item
+            for index in range(n):
+                cached_item = cache.popleft()[1]
+                if index % step == 0:
+                    yield cached_item
         elif (stop is not None) and (stop < 0):
             # Advance to the start position
             next(islice(it, start, start), None)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2632,9 +2632,14 @@ def _islice_helper(it, s):
                 return
 
             for index in range(n):
-                cached_item = cache.popleft()[1]
                 if index % step == 0:
-                    yield cached_item
+                    # pop and yield the item.
+                    # We don't want to use an intermediate variable
+                    # it would extend the lifetime of the current item
+                    yield cache.popleft()[1]
+                else:
+                    # just pop and discard the item
+                    cache.popleft()
         elif (stop is not None) and (stop < 0):
             # Advance to the start position
             next(islice(it, start, start), None)


### PR DESCRIPTION
Ensure we release iterated elements as soon as `start<0` and `step>0`.
We're currently holding a reference on all the elements until we've completed a full iteration.

See https://github.com/more-itertools/more-itertools/issues/994 for a detailed example.

### Issue reference
more-itertools/more-itertools#994

### Changes
In this specific case, improved the iteration over the cached data, by also releasing elements after having been yield.

### Checks and tests
```
test_all (tests.test_more.IsliceExtendedTests.test_all) ... ok
test_invalid_slice (tests.test_more.IsliceExtendedTests.test_invalid_slice) ... ok
test_slicing (tests.test_more.IsliceExtendedTests.test_slicing) ... ok
test_slicing_extensive (tests.test_more.IsliceExtendedTests.test_slicing_extensive) ... ok
test_zero_step (tests.test_more.IsliceExtendedTests.test_zero_step) ... ok
```
