### PR TITLE
convolve() is agnostic to endianness

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -760,8 +760,6 @@ def convolve(signal, kernel):
         >>> list(convolve([1, -1, -20], [1, -3]))
         [1, -4, -17, 60]
 
-    Note that polynomial coefficients are specified in descending power order.
-
     Examples of popular kinds of kernels:
 
     * The kernel ``[0.25, 0.25, 0.25, 0.25]`` computes a moving average.


### PR DESCRIPTION
Unlike the other polynomial functions, `convolve()` has no intrinsic notion of endianness.  It's big endian in, big endian out and little endian in, little endian out.

```python
list(convolve([1, -1, -20], [1, -3]))
[1, -4, -17, 60]
list(convolve([-20, -1, 1], [-3, 1]))
[60, -17, -4, 1]
```