### PR TITLE
Sample simplification

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3722,8 +3722,9 @@ def _sample_unweighted(iterator, k, strict):
     W = 1.0
 
     with suppress(StopIteration):
+        rk = 1 / k
         while True:
-            W *= exp(log(random()) / k)
+            W *= random() ** rk
             skip = floor(log(random()) / log1p(-W))
             element = next(islice(iterator, skip, None))
             reservoir[randrange(k)] = element
@@ -3796,8 +3797,9 @@ def _sample_counted(population, k, counts, strict):
 
     with suppress(StopIteration):
         W = 1.0
+        rk = 1 / k
         while True:
-            W *= exp(log(random()) / k)
+            W *= random() ** rk
             skip = floor(log(random()) / log1p(-W))
             element = feed(skip)
             reservoir[randrange(k)] = element

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4430,6 +4430,21 @@ class MapIfTests(TestCase):
 
 
 class SampleTests(TestCase):
+
+    def test_specific_sample(self):
+        """Verify reproducibility."""
+        seed(8675309)
+        self.assertEqual(list(mi.sample(range(10**5), k=5)),
+                         [16845, 79805, 76057, 58302, 40472])
+
+        seed(8675309)
+        self.assertEqual(list(mi.sample(range(10**5), counts=[1,2] * (10**5 // 2), k=5)),
+                             [87899, 53203, 38868, 11230, 50705])
+
+        seed(8675309)
+        self.assertEqual(list(mi.sample(range(10**5), weights=range(1, 10**5+1), k=5)),
+                             [50915, 33816, 32250, 98284, 43517])
+
     def test_unit_case(self):
         """Test against a fixed case by seeding the random module."""
         # Beware that this test really just verifies random.random() behavior.

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4433,17 +4433,20 @@ class SampleTests(TestCase):
 
     def test_specific_sample(self):
         """Verify reproducibility."""
+        # Note, this test is fragile because it depends on the quality of
+        # the underlying libmath implementations for log, exp, and log1p.
+
         seed(8675309)
         self.assertEqual(list(mi.sample(range(10**5), k=5)),
                          [16845, 79805, 76057, 58302, 40472])
 
         seed(8675309)
         self.assertEqual(list(mi.sample(range(10**5), counts=[1,2] * (10**5 // 2), k=5)),
-                             [87899, 53203, 38868, 11230, 50705])
+                         [87899, 53203, 38868, 11230, 50705])
 
         seed(8675309)
         self.assertEqual(list(mi.sample(range(10**5), weights=range(1, 10**5+1), k=5)),
-                             [50915, 33816, 32250, 98284, 43517])
+                         [50915, 33816, 32250, 98284, 43517])
 
     def test_unit_case(self):
         """Test against a fixed case by seeding the random module."""


### PR DESCRIPTION
Simplify `exp(log(x) / k)` to `x ** (1 / k)`.

This looks nicer and is more idiomatic.

It is possibly more accurate with only one call to `pow()` instead of nested calls to `exp` and `log`. 

Also, it runs faster:

```
% python3.14 -m timeit -s 'from math import log, exp' -s 'x, k = 0.1234, 23' 'exp(log(x) / k)'
5000000 loops, best of 5: 52.4 nsec per loop

% python3.14 -m timeit -s 'from math import log, exp' -s 'x, k = 0.1234, 23' -s 'rk = 1/k' 'x ** rk'
10000000 loops, best of 5: 30.4 nsec per loop
```

If the test is too fragile, rip it out.  It passes for me on all supported mac builds and on pypy3.
