### PR TITLE
Add an option for nth_prime() to be approximated

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -35,7 +35,9 @@ from .recipes import (
     _zip_equal,
     UnequalIterablesError,
     consume,
+    first_true,
     flatten,
+    is_prime,
     nth,
     powerset,
     sieve,
@@ -5070,18 +5072,36 @@ def _nth_prime_ub(n):
     return ub
 
 
-def nth_prime(n):
+def nth_prime(n, *, approximate=False):
     """Return the nth prime (counting from 0).
 
     >>> nth_prime(0)
     2
     >>> nth_prime(100)
     547
+
+    If *approximate* is set to True, will return a prime in the close
+    to the nth prime.  The estimation is much faster than computing
+    an exact result.
+
+    >>> nth_prime(100_000_000, approximate=True)  # Exact result is 2038074751
+    2038374449
+
     """
     if n < 0:
         raise ValueError
+
     limit = math.ceil(_nth_prime_ub(n + 1))
-    return nth(sieve(limit), n)
+
+    if not approximate or n <= 1_000_000:
+        return nth(sieve(limit), n)
+
+    # Round to closest odd within the bounds
+    ub = floor(limit)
+    if not ub & 1:
+        ub -= 1
+
+    return first_true(count(ub, step=-2), pred=is_prime)
 
 
 def argmin(iterable, *, key=None):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5061,7 +5061,13 @@ def doublestarmap(func, iterable):
 def _nth_prime_ub(n):
     "Upper bound for the nth prime (counting from 1)."
     # https://en.wikipedia.org/wiki/Prime-counting_function#Inequalities
-    return n * log(n * log(n)) if n >= 6 else 11.1
+    ub = 11.1
+    if n >= 6:
+        ub = n * log(n * log(n))
+    if n >= 688_383:
+        # Make ub accurate to within n * 0.003
+        ub -= n * (1.0 - (log(log(n)) - 2.0) / log(n))
+    return ub
 
 
 def nth_prime(n):


### PR DESCRIPTION
This makes `nth_prime()` usable with larger values of *n*.

```
% time python3.14 -c 'from more_itertools import nth_prime; nth_prime(100_000_000)' 
14.30s user 0.51s system 99% cpu 14.820 total

% time python3.14 -c 'from more_itertools import nth_prime; nth_prime(100_000_000, approximate=True)'
python3.14 -c   0.03s user 0.01s system 88% cpu 0.046 total
```