### PR TITLE
Improve islice_extended memory usage when step<0

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2689,7 +2689,7 @@ def _islice_helper(it, s):
                 i = min(start - len_iter, -1)
 
             # Advance to the start position
-            for _ in range(min(-i-1, len(cache))):
+            for _ in range(min(-i - 1, len(cache))):
                 cache.pop()
 
             for index in range(len(cache)):
@@ -2711,7 +2711,7 @@ def _islice_helper(it, s):
                 cache = deque(it)
 
                 # Advance to the start position
-                for _ in range(min(-start-1, len(cache))):
+                for _ in range(min(-start - 1, len(cache))):
                     cache.pop()
             else:
                 # stop is None and start is positive, so we just need items up to

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2680,16 +2680,14 @@ def _islice_helper(it, s):
             cache = deque(enumerate(it, 1), maxlen=n)
             len_iter = cache[-1][0] if cache else 0
 
-            # If start and stop are both negative they are comparable and
-            # we can just slice. Otherwise we can adjust start to be negative
-            # and then slice.
+            # compute how many elements are out of bound
             if start < 0:
-                i = start
+                after_start_elements = min(-start - 1, len(cache))
             else:
-                i = min(start - len_iter, -1)
+                after_start_elements = min(len_iter - (start + 1), len(cache))
 
-            # Advance to the start position
-            for _ in range(min(-i - 1, len(cache))):
+            # Remove any element after start index, they are out of bound
+            for _ in range(after_start_elements):
                 cache.pop()
 
             for index in range(len(cache)):
@@ -2710,12 +2708,13 @@ def _islice_helper(it, s):
             if start < 0:
                 cache = deque(it)
 
-                # Advance to the start position
-                for _ in range(min(-start - 1, len(cache))):
+                # Remove any element after start index, they are out of bound
+                after_start_elements = min(-start - 1, len(cache))
+                for _ in range(after_start_elements):
                     cache.pop()
             else:
-                # stop is None and start is positive, so we just need items up to
-                # the start index.
+                # stop is None and start is positive, so we just need items
+                # up to the start index.
                 if stop is None:
                     n = start + 1
                 # Both stop and start are positive, so they are comparable.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2684,11 +2684,11 @@ def _islice_helper(it, s):
             # we can just slice. Otherwise we can adjust start to be negative
             # and then slice.
             if start < 0:
-                i, j = start, stop
+                i = start
             else:
-                i, j = min(start - len_iter, -1), None
+                i = min(start - len_iter, -1)
 
-            for index, item in list(cache)[i:j:step]:
+            for index, item in list(cache)[i::step]:
                 yield item
         else:
             # Advance to the stop position

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2701,44 +2701,30 @@ def _islice_helper(it, s):
                 else:
                     # just pop and discard the item
                     cache.pop()
-        elif start < 0:
-            # Advance to the stop position
-            if stop is not None:
-                m = stop + 1
-                next(islice(it, m, m), None)
-            
-            cache = deque(it)
-
-            # Advance to the start position
-            for _ in range(min(-start-1, len(cache))):
-                cache.pop()
-
-            for index in range(len(cache)):
-                if index % step == 0:
-                    # pop and yield the item.
-                    # We don't want to use an intermediate variable
-                    # it would extend the lifetime of the current item
-                    yield cache.pop()
-                else:
-                    # just pop and discard the item
-                    cache.pop()
         else:
             # Advance to the stop position
             if stop is not None:
                 m = stop + 1
                 next(islice(it, m, m), None)
 
-            # stop is None and start is positive, so we just need items up to
-            # the start index.
-            if stop is None:
-                n = start + 1
-            # Both stop and start are positive, so they are comparable.
-            else:
-                n = start - stop
-                if n <= 0:
-                    return
+            if start < 0:
+                cache = deque(it)
 
-            cache = deque(islice(it, n))
+                # Advance to the start position
+                for _ in range(min(-start-1, len(cache))):
+                    cache.pop()
+            else:
+                # stop is None and start is positive, so we just need items up to
+                # the start index.
+                if stop is None:
+                    n = start + 1
+                # Both stop and start are positive, so they are comparable.
+                else:
+                    n = start - stop
+                    if n <= 0:
+                        return
+
+                cache = deque(islice(it, n))
 
             for index in range(len(cache)):
                 if index % step == 0:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2731,18 +2731,24 @@ def _islice_helper(it, s):
             # stop is None and start is positive, so we just need items up to
             # the start index.
             if stop is None:
-                i = None
                 n = start + 1
             # Both stop and start are positive, so they are comparable.
             else:
-                i = None
                 n = start - stop
                 if n <= 0:
                     return
 
-            cache = list(islice(it, n))
+            cache = deque(islice(it, n))
 
-            yield from cache[i::step]
+            for index in range(len(cache)):
+                if index % step == 0:
+                    # pop and yield the item.
+                    # We don't want to use an intermediate variable
+                    # it would extend the lifetime of the current item
+                    yield cache.pop()
+                else:
+                    # just pop and discard the item
+                    cache.pop()
 
 
 def always_reversible(iterable):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2701,20 +2701,36 @@ def _islice_helper(it, s):
                 else:
                     # just pop and discard the item
                     cache.pop()
+        elif start < 0:
+            # Advance to the stop position
+            if stop is not None:
+                m = stop + 1
+                next(islice(it, m, m), None)
+            
+            cache = deque(it)
+
+            # Advance to the start position
+            for _ in range(min(-start-1, len(cache))):
+                cache.pop()
+
+            for index in range(len(cache)):
+                if index % step == 0:
+                    # pop and yield the item.
+                    # We don't want to use an intermediate variable
+                    # it would extend the lifetime of the current item
+                    yield cache.pop()
+                else:
+                    # just pop and discard the item
+                    cache.pop()
         else:
             # Advance to the stop position
             if stop is not None:
                 m = stop + 1
                 next(islice(it, m, m), None)
 
-            # stop is positive, so if start is negative they are not comparable
-            # and we need the rest of the items.
-            if start < 0:
-                i = start
-                n = None
             # stop is None and start is positive, so we just need items up to
             # the start index.
-            elif stop is None:
+            if stop is None:
                 i = None
                 n = start + 1
             # Both stop and start are positive, so they are comparable.

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2688,8 +2688,19 @@ def _islice_helper(it, s):
             else:
                 i = min(start - len_iter, -1)
 
-            for index, item in list(cache)[i::step]:
-                yield item
+            # Advance to the start position
+            for _ in range(min(-i-1, len(cache))):
+                cache.pop()
+
+            for index in range(len(cache)):
+                if index % step == 0:
+                    # pop and yield the item.
+                    # We don't want to use an intermediate variable
+                    # it would extend the lifetime of the current item
+                    yield cache.pop()[1]
+                else:
+                    # just pop and discard the item
+                    cache.pop()
         else:
             # Advance to the stop position
             if stop is not None:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3372,16 +3372,12 @@ class IsliceExtendedTests(TestCase):
 
             # testcases for: start>0, stop>0, step<0
             TestCase(initialSize=3, slice=(None, None, -1), expectedAliveStates=[  # noqa: E501
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(2, None, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(None, 0, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=6, slice=(3, 1, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1, 1, 1, 1], [0, 0, 1, 0, 1, 1], [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 1, 1]]),  # noqa: E501
             TestCase(initialSize=5, slice=(1, 3, -1), expectedAliveStates=[
                 # ⚠️could be improved. Final state could be [0, 0, 1, 1, 1]
@@ -3389,29 +3385,22 @@ class IsliceExtendedTests(TestCase):
 
             # testcases for: start<0, stop>0, step<0
             TestCase(initialSize=3, slice=(-1, None, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(-1, 0, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=6, slice=(-2, None, -2), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0], [1, 1, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
             TestCase(initialSize=6, slice=(-2, 1, -2), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
             TestCase(initialSize=6, slice=(-4, 4, -2), expectedAliveStates=[
                 [1, 1, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]),
 
             # testcases for: start>0, stop<0, step<0
             TestCase(initialSize=3, slice=(None, -3, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(None, -4, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=5, slice=(3, -4, -1), expectedAliveStates=[
-                # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1, 1, 1], [0, 0, 1, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]),   # noqa: E501
             TestCase(initialSize=5, slice=(1, -1, -1), expectedAliveStates=[
                 [1, 1, 1, 1, 1], [0, 0, 0, 0, 0]]),

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3373,13 +3373,13 @@ class IsliceExtendedTests(TestCase):
             # testcases for: start>0, stop>0, step<0
             TestCase(initialSize=3, slice=(None, None, -1), expectedAliveStates=[  # noqa: E501
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(2, None, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(None, 0, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [0, 1, 1], [0, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=6, slice=(3, 1, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1]]),  # noqa: E501
@@ -3390,16 +3390,16 @@ class IsliceExtendedTests(TestCase):
             # testcases for: start<0, stop>0, step<0
             TestCase(initialSize=3, slice=(-1, None, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(-1, 0, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [0, 1, 1], [0, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=6, slice=(-2, None, -2), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
+                [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0], [1, 1, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
             TestCase(initialSize=6, slice=(-2, 1, -2), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
+                [1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]),  # noqa: E501
             TestCase(initialSize=6, slice=(-4, 4, -2), expectedAliveStates=[
                 [1, 1, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]),
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3376,13 +3376,13 @@ class IsliceExtendedTests(TestCase):
                 [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(2, None, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(None, 0, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
                 [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=6, slice=(3, 1, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 1, 1]]),  # noqa: E501
+                [1, 1, 1, 1, 1, 1], [0, 0, 1, 0, 1, 1], [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 1, 1]]),  # noqa: E501
             TestCase(initialSize=5, slice=(1, 3, -1), expectedAliveStates=[
                 # ⚠️could be improved. Final state could be [0, 0, 1, 1, 1]
                 [1, 1, 1, 1, 1], [0, 0, 0, 0, 1]]),

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3406,13 +3406,13 @@ class IsliceExtendedTests(TestCase):
             # testcases for: start>0, stop<0, step<0
             TestCase(initialSize=3, slice=(None, -3, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [0, 1, 1], [0, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [0, 1, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=3, slice=(None, -4, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0]]),
+                [1, 1, 1], [1, 1, 0], [1, 0, 0], [0, 0, 0], [0, 0, 0]]),
             TestCase(initialSize=5, slice=(3, -4, -1), expectedAliveStates=[
                 # ⚠️could be improved, elements are only released on final step
-                [1, 1, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 0, 0, 0]]),   # noqa: E501
+                [1, 1, 1, 1, 1], [0, 0, 1, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]),   # noqa: E501
             TestCase(initialSize=5, slice=(1, -1, -1), expectedAliveStates=[
                 [1, 1, 1, 1, 1], [0, 0, 0, 0, 0]]),
         ]


### PR DESCRIPTION
### Issue reference
- more-itertools/more-itertools#1013

This is a follow up on the following issues/pull requests that were covering the `step>0` cases:
Issues:
- more-itertools/more-itertools#994
- more-itertools/more-itertools#1011
Pull requests:
- more-itertools/more-itertools#995 (`start<0`, `step>0`)
- more-itertools/more-itertools#996 (unit test)
- more-itertools/more-itertools#999 (`stop<0`, `step>0`)

### Changes
- Ensure that iterated elements that have been returned are not referenced anymore by `islice_extended` when `step<0`.
- Updated `tests.test_more.IsliceExtendedTests.test_elements_lifecycle` unit test accordingly.

ℹ️ Review this pull request by looking at the intermediate commits, is probably easier. Each sub-case has been handled in a separate commit, and unit test has also been updated on each intermediate commit, if needed.

### Checks and tests
```
ruff format .
15 files left unchanged
```
```
coverage report --show-missing --fail-under=999
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
more_itertools\__init__.py       4      0   100%
more_itertools\more.py        1618      1    99%   3425
more_itertools\recipes.py      354     16    95%   95-96, 104-105, 344-345, 994-1012, 1066
----------------------------------------------------------
```
```
test_all (tests.test_more.IsliceExtendedTests.test_all) ... ok
test_elements_lifecycle (tests.test_more.IsliceExtendedTests.test_elements_lifecycle) ... ok
test_invalid_slice (tests.test_more.IsliceExtendedTests.test_invalid_slice) ... ok
test_slicing (tests.test_more.IsliceExtendedTests.test_slicing) ... ok
test_slicing_extensive (tests.test_more.IsliceExtendedTests.test_slicing_extensive) ... ok
test_zero_step (tests.test_more.IsliceExtendedTests.test_zero_step) ... ok

----------------------------------------------------------------------
Ran 6 tests in 0.712s

OK
Finished running tests!
```
