### PR TITLE
Add derangements() to the doc indexes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,8 @@ Python iterables.
 |                        | `nth_prime <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.nth_prime>`_,                                                                           |
 |                        | `sieve <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.sieve>`_,                                                                                   |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Combinatorics          | `distinct_permutations <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.distinct_permutations>`_,                                                   |
+| Combinatorics          | `derangements <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.derangements>`_,                                                                     |
+|                        | `distinct_permutations <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.distinct_permutations>`_,                                                   |
 |                        | `distinct_combinations <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.distinct_combinations>`_,                                                   |
 |                        | `circular_shifts <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.circular_shifts>`_,                                                               |
 |                        | `partitions <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.partitions>`_,                                                                         |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,6 +223,7 @@ These tools yield combinatorial arrangements of items from iterables.
 
 **New itertools**
 
+.. autofunction:: derangements
 .. autofunction:: distinct_permutations
 .. autofunction:: distinct_combinations
 .. autofunction:: nth_combination_with_replacement

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -850,7 +850,9 @@ def derangements(iterable, r=None):
     """Yield successive derangements of the elements in *iterable*.
 
     A derangement is a permutation in which no element appears at its original
-    index. Suppose Alice, Bob, Carol, and Dave are playing Secret Santa.
+    index. In other words, a derangement is a permutation that has no fixed points.
+
+    Suppose Alice, Bob, Carol, and Dave are playing Secret Santa.
     The code below outputs all of the different ways to assign gift recipients
     such that nobody is assigned to himself or herself:
 
@@ -876,6 +878,10 @@ def derangements(iterable, r=None):
     Elements are treated as unique based on their position, not on their value.
     If the input elements are unique, there will be no repeated values within a
     permutation.
+
+    The number of derangements of a set of size *n* is known as the
+    "subfactorial of n".  For n > 0, the subfactorial is:
+    ``round(math.factorial(n) / math.e)``.
     """
     xs = tuple(zip(iterable))
     for ys in permutations(xs, r=r):


### PR DESCRIPTION
* Add `derangements()` to `README.rst` and `API.rst`.
* Expand docstring to include the expected size of the iterator.