### PR TITLE
Issue 1001: fix last() when __reversed__ is None

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -283,7 +283,7 @@ def last(iterable, default=_marker):
         if isinstance(iterable, Sequence):
             return iterable[-1]
         # Work around https://bugs.python.org/issue38525
-        if hasattr(iterable, '__reversed__'):
+        if getattr(iterable, '__reversed__', None):
             return next(reversed(iterable))
         return deque(iterable, maxlen=1)[-1]
     except (IndexError, TypeError, StopIteration):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -180,6 +180,16 @@ class LastTests(TestCase):
                 with self.assertRaises(ValueError):
                     mi.last(iterable)
 
+    def test_reversed_is_none(self):
+        # See https://github.com/more-itertools/more-itertools/issues/1001
+        class ReversedIsNone:
+            __reversed__ = None
+
+            def __iter__(self):
+                return iter([1])
+
+        self.assertEqual(mi.last(ReversedIsNone()), 1)
+
 
 class NthOrLastTests(TestCase):
     """Tests for ``nth_or_last()``"""


### PR DESCRIPTION
Fixes #1001 by swapping `hasattr` with `getattr`.

We might consider a stronger check that `iterable.__reversed__` is callable, but that seems unnecessary given expected usage.