### PR TITLE
Issue 1029: fix batched IDE/help() docs

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -993,10 +993,9 @@ if hexversion >= 0x30D00A2:  # pragma: no cover
     def batched(iterable, n, *, strict=False):
         return itertools_batched(iterable, n, strict=strict)
 
+    batched.__doc__ = _batched.__doc__
 else:
     batched = _batched
-
-    batched.__doc__ = _batched.__doc__
 
 
 def transpose(it):

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -168,9 +168,12 @@ def iter_index(
     stop: int | None = ...,
 ) -> Iterator[int]: ...
 def sieve(n: int) -> Iterator[int]: ...
-def batched(
+def _batched(
     iterable: Iterable[_T], n: int, *, strict: bool = False
 ) -> Iterator[tuple[_T, ...]]: ...
+
+batched = _batched
+
 def transpose(
     it: Iterable[Iterable[_T]],
 ) -> Iterator[tuple[_T, ...]]: ...


### PR DESCRIPTION
Fixes #1029

1. `help(batched)` in 3.13+ is useful
```py
Help on function batched in module more_itertools.recipes:

batched(iterable, n, *, strict=False)
    Batch data into tuples of length *n*. If the number of items in
    *iterable* is not divisible by *n*:
    * The last batch will be shorter if *strict* is ``False``.
    * :exc:`ValueError` will be raised if *strict* is ``True``.

    >>> list(batched('ABCDEFG', 3))
    [('A', 'B', 'C'), ('D', 'E', 'F'), ('G',)]

    On Python 3.13 and above, this is an alias for :func:`itertools.batched`.
```
2. IDE doc string is useful
<img width="632" height="280" alt="image" src="https://github.com/user-attachments/assets/fc9f7e86-3206-4d46-93d9-29cf588df45b" />
