### PR TITLE
Increase always_iterable typing accuracy.

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -452,7 +452,7 @@ def unzip(iterable: Iterable[Sequence[_T]]) -> tuple[Iterator[_T], ...]: ...
 def divide(n: int, iterable: Iterable[_T]) -> list[Iterator[_T]]: ...
 @overload
 def always_iterable(
-    obj: None, base_type: _ClassInfo | None = ...
+    obj: None, base_type: _ClassInfo | None
 ) -> Iterator[Never]: ...
 @overload
 def always_iterable(obj: bytes) -> Iterator[bytes]: ...
@@ -460,25 +460,23 @@ def always_iterable(obj: bytes) -> Iterator[bytes]: ...
 def always_iterable(obj: str) -> Iterator[str]: ...
 @overload
 def always_iterable(
-    obj: Iterable[_T],
+    obj: Iterable[_T] | _SupportsSlicing[_T],
 ) -> Iterator[_T]: ...
-@overload
-def always_iterable(obj: _T) -> Iterator[_T]: ...
 @overload
 def always_iterable(
-    obj: Iterable[_T],
-    base_type: None,
+    obj: Iterable[_T] | _SupportsSlicing[_T],
+    base_type: None | tuple[()],
 ) -> Iterator[_T]: ...
+@overload
+def always_iterable(
+    obj: Iterable[_T] | _SupportsSlicing[_T],
+    base_type: _ClassInfo,
+) -> Iterator[_T | Iterable[_T] | _SupportsSlicing[_T]]: ...
 @overload
 def always_iterable(
     obj: _T,
-    base_type: None,
+    base_type: _ClassInfo | None,
 ) -> Iterator[_T]: ...
-@overload
-def always_iterable(
-    obj: _T | Iterable[_T],
-    base_type: _ClassInfo = ...,
-) -> Iterator[_T | Iterable[_T]]: ...
 def adjacent(
     predicate: Callable[[_T], bool],
     iterable: Iterable[_T],


### PR DESCRIPTION
### Issue reference
closes more-itertools/more-itertools#1032

### Changes
Attempt at increasing the typehint precision for always Iterable.

while the general case is still slightly flaky, I am not sure how to write better typehints in light of the second attribute (on which the return value depends). However, I added several overloads which should help with use without the second argument.

### Checks and tests
 - [x] ran the checks
