### PR TITLE
Fix docstring and comment in private _nth_prime_bounds function

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5137,8 +5137,6 @@ def nth_prime(n, *, approximate=False):
     >>> nth_prime(200_000_000, approximate=True)  # Exact result is 4222234763
     4217820427
 
-    In the future, more accurate approximations may be returned.
-
     """
     lb, ub = _nth_prime_bounds(n + 1)
 


### PR DESCRIPTION
* The sieve call in `nth_prime` relies on the upper bound being exclusive.  Adjust the comment in `_nth_prime_bounds function` to match.  Demonstration:

```python
for n, p in enumerate(sieve(10**8), start=1):
    l, u = _nth_prime_bounds(n)
    assert l < p < u
```

* The spread ratio noted in the comment should be relative to the nth prime rather than *n*.

```python
>>> l, u = _nth_prime_bounds(688_383)
>>> (u - l) / l
0.0029597587292980792
```

* Note that tighter estimates may be added in the future. See https://cs.uwaterloo.ca/journals/JIS/VOL22/Axler/axler17.pdf for some of the possiblities.