### PR TITLE
docs: Fix invisible REPL output in HTML dark mode

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,10 @@ exclude_patterns = [build_dir]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Pygments syntax highlighting theme when broswer or user has chosen dark mode.
+# Setting is specific to furo HTML theme.
+pygments_dark_style = "monokai"
+
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 


### PR DESCRIPTION
With the sphinx theme output was rendered in virtually the same colour as the background. The light theme should be unchanged.

See
- https://pradyunsg.me/furo/customisation/colors/#code-block-styling

### Issue reference
None

### Changes
Changes the Pygments theme for code blocks in HTML dark mode to "monokai"

#### Before
<img width="1472" height="508" alt="Screenshot 2025-08-06 at 14-22-01 API Reference - more-itertools 10 7 0 documentation" src="https://github.com/user-attachments/assets/a707f074-a77b-43ef-8934-32b2deee102e" />

#### After
<img width="1472" height="508" alt="Screenshot 2025-08-06 at 14-22-28 API Reference - more-itertools 10 7 0 documentation" src="https://github.com/user-attachments/assets/0b33b6dc-f51f-4b74-8a46-8a75bc674852" />

### Checks and tests

<details>

```
➜  more-itertools git:(pygments-dark) . .venv/bin/activate
(more-itertools) ➜  more-itertools git:(pygments-dark) make all-checks     
python3 -m pip install -r requirements/development.txt
Requirement already satisfied: coverage in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 1)) (7.10.2)
Requirement already satisfied: flit in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 2)) (3.12.0)
Requirement already satisfied: mypy in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 3)) (1.17.1)
Requirement already satisfied: ruff in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 4)) (0.12.7)
Requirement already satisfied: setuptools in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 5)) (80.9.0)
Requirement already satisfied: sphinx in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 6)) (8.2.3)
Requirement already satisfied: furo>=2024.8 in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 7)) (2024.8.6)
Requirement already satisfied: twine in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 8)) (6.1.0)
Requirement already satisfied: wheel in ./.venv/lib/python3.13/site-packages (from -r requirements/development.txt (line 9)) (0.45.1)
Requirement already satisfied: flit_core>=3.12.0 in ./.venv/lib/python3.13/site-packages (from flit->-r requirements/development.txt (line 2)) (3.12.0)
Requirement already satisfied: requests in ./.venv/lib/python3.13/site-packages (from flit->-r requirements/development.txt (line 2)) (2.32.4)
Requirement already satisfied: docutils in ./.venv/lib/python3.13/site-packages (from flit->-r requirements/development.txt (line 2)) (0.21.2)
Requirement already satisfied: tomli-w in ./.venv/lib/python3.13/site-packages (from flit->-r requirements/development.txt (line 2)) (1.2.0)
Requirement already satisfied: pip in ./.venv/lib/python3.13/site-packages (from flit->-r requirements/development.txt (line 2)) (25.2)
Requirement already satisfied: typing_extensions>=4.6.0 in ./.venv/lib/python3.13/site-packages (from mypy->-r requirements/development.txt (line 3)) (4.14.1)
Requirement already satisfied: mypy_extensions>=1.0.0 in ./.venv/lib/python3.13/site-packages (from mypy->-r requirements/development.txt (line 3)) (1.1.0)
Requirement already satisfied: pathspec>=0.9.0 in ./.venv/lib/python3.13/site-packages (from mypy->-r requirements/development.txt (line 3)) (0.12.1)
Requirement already satisfied: sphinxcontrib-applehelp>=1.0.7 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.0.0)
Requirement already satisfied: sphinxcontrib-devhelp>=1.0.6 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.0.0)
Requirement already satisfied: sphinxcontrib-htmlhelp>=2.0.6 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.1.0)
Requirement already satisfied: sphinxcontrib-jsmath>=1.0.1 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (1.0.1)
Requirement already satisfied: sphinxcontrib-qthelp>=1.0.6 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.0.0)
Requirement already satisfied: sphinxcontrib-serializinghtml>=1.1.9 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.0.0)
Requirement already satisfied: Jinja2>=3.1 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (3.1.6)
Requirement already satisfied: Pygments>=2.17 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.19.2)
Requirement already satisfied: snowballstemmer>=2.2 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (3.0.1)
Requirement already satisfied: babel>=2.13 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (2.17.0)
Requirement already satisfied: alabaster>=0.7.14 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (1.0.0)
Requirement already satisfied: imagesize>=1.3 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (1.4.1)
Requirement already satisfied: roman-numerals-py>=1.0.0 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (3.1.0)
Requirement already satisfied: packaging>=23.0 in ./.venv/lib/python3.13/site-packages (from sphinx->-r requirements/development.txt (line 6)) (25.0)
Requirement already satisfied: beautifulsoup4 in ./.venv/lib/python3.13/site-packages (from furo>=2024.8->-r requirements/development.txt (line 7)) (4.13.4)
Requirement already satisfied: sphinx-basic-ng>=1.0.0.beta2 in ./.venv/lib/python3.13/site-packages (from furo>=2024.8->-r requirements/development.txt (line 7)) (1.0.0b2)
Requirement already satisfied: readme-renderer>=35.0 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (44.0)
Requirement already satisfied: requests-toolbelt!=0.9.0,>=0.8.0 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (1.0.0)
Requirement already satisfied: urllib3>=1.26.0 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (2.5.0)
Requirement already satisfied: keyring>=15.1 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (25.6.0)
Requirement already satisfied: rfc3986>=1.4.0 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (2.0.0)
Requirement already satisfied: rich>=12.0.0 in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (14.1.0)
Requirement already satisfied: id in ./.venv/lib/python3.13/site-packages (from twine->-r requirements/development.txt (line 8)) (1.5.0)
Requirement already satisfied: MarkupSafe>=2.0 in ./.venv/lib/python3.13/site-packages (from Jinja2>=3.1->sphinx->-r requirements/development.txt (line 6)) (3.0.2)
Requirement already satisfied: jaraco.classes in ./.venv/lib/python3.13/site-packages (from keyring>=15.1->twine->-r requirements/development.txt (line 8)) (3.4.0)
Requirement already satisfied: jaraco.functools in ./.venv/lib/python3.13/site-packages (from keyring>=15.1->twine->-r requirements/development.txt (line 8)) (4.2.1)
Requirement already satisfied: jaraco.context in ./.venv/lib/python3.13/site-packages (from keyring>=15.1->twine->-r requirements/development.txt (line 8)) (6.0.1)
Requirement already satisfied: nh3>=0.2.14 in ./.venv/lib/python3.13/site-packages (from readme-renderer>=35.0->twine->-r requirements/development.txt (line 8)) (0.3.0)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.venv/lib/python3.13/site-packages (from requests->flit->-r requirements/development.txt (line 2)) (3.4.2)
Requirement already satisfied: idna<4,>=2.5 in ./.venv/lib/python3.13/site-packages (from requests->flit->-r requirements/development.txt (line 2)) (3.10)
Requirement already satisfied: certifi>=2017.4.17 in ./.venv/lib/python3.13/site-packages (from requests->flit->-r requirements/development.txt (line 2)) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.venv/lib/python3.13/site-packages (from rich>=12.0.0->twine->-r requirements/development.txt (line 8)) (3.0.0)
Requirement already satisfied: mdurl~=0.1 in ./.venv/lib/python3.13/site-packages (from markdown-it-py>=2.2.0->rich>=12.0.0->twine->-r requirements/development.txt (line 8)) (0.1.2)
Requirement already satisfied: soupsieve>1.2 in ./.venv/lib/python3.13/site-packages (from beautifulsoup4->furo>=2024.8->-r requirements/development.txt (line 7)) (2.7)
Requirement already satisfied: more-itertools in ./.venv/lib/python3.13/site-packages (from jaraco.classes->keyring>=15.1->twine->-r requirements/development.txt (line 8)) (10.7.0)
python3 -m pip install --editable .
Obtaining file:///Users/alex/src/more-itertools
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: more-itertools
  Building editable for more-itertools (pyproject.toml) ... done
  Created wheel for more-itertools: filename=more_itertools-10.7.0-py3-none-any.whl size=5440 sha256=976c2367d03e6800516f82f4fe976975f06375109bb54befaa1d456aaca5f243
  Stored in directory: /private/var/folders/hw/y1c1nkcs3ls5j9kv5rr_tn040000gn/T/pip-ephem-wheel-cache-pqwavohw/wheels/cf/a9/4f/54f725f20acaa5aa578fb2ded31bdb5ee7ad675a21d5bab703
Successfully built more-itertools
Installing collected packages: more-itertools
  Attempting uninstall: more-itertools
    Found existing installation: more-itertools 10.7.0
    Uninstalling more-itertools-10.7.0:
      Successfully uninstalled more-itertools-10.7.0
Successfully installed more-itertools-10.7.0
coverage run --include="more_itertools/*.py" -m unittest
....................................................................................................................................................................................................................................................................................................................................................................................................................................../Users/alex/src/more-itertools/more_itertools/more.py:1838: DeprecationWarning: zip_equal will be removed in a future version of more-itertools. Use the builtin zip function with strict=True instead.
  warnings.warn(
...................................................................................................................../Users/alex/src/more-itertools/more_itertools/more.py:1838: DeprecationWarning: zip_equal will be removed in a future version of more-itertools. Use the builtin zip function with strict=True instead.
  warnings.warn(
................................................................................s..................................................................................................................................................................s.........................................ssss.................
----------------------------------------------------------------------
Ran 845 tests in 30.286s

OK (skipped=6)
coverage report --show-missing --fail-under=99
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
more_itertools/__init__.py       3      0   100%
more_itertools/more.py        1629      1    99%   3438
more_itertools/recipes.py      366      9    98%   99-100, 108-109, 116, 357-358, 1012, 1421
----------------------------------------------------------
TOTAL                         1998     10    99%
ruff format --check .
10 files already formatted
ruff check more_itertools tests
All checks passed!
stubtest more_itertools.more more_itertools.recipes
Success: no issues found in 2 modules
sphinx-build -W -b html docs docs/_build/html
Running Sphinx v8.2.3
loading translations [en]... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
loading pickled environment... The configuration has changed (2 options: 'html_css_files', 'pygments_dark_style')
done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 4 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] index
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /Users/alex/src/more-itertools/docs/_build/html/_static/basic.css
Writing evaluated template result to /Users/alex/src/more-itertools/docs/_build/html/_static/language_data.js
Writing evaluated template result to /Users/alex/src/more-itertools/docs/_build/html/_static/documentation_options.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [100%] versions
generating indices... genindex py-modindex done
highlighting module code... [100%] more_itertools.recipes
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in docs/_build/html.
flit build --setup-py
Fetching list of valid trove classifiers                                                               I-flit.validate
Found 36 files tracked in git                                                                             I-flit.sdist
Writing generated setup.py                                                                                I-flit.sdist
Built sdist: dist/more_itertools-10.7.0.tar.gz                                                       I-flit_core.sdist
Copying package file(s) from /var/folders/hw/y1c1nkcs3ls5j9kv5rr_tn040000gn/T/tmpbhynrov_/more_itertools-10.7.0/more_itertools  I-flit_core.wheel
Writing metadata files                                                                               I-flit_core.wheel
Writing the record of files                                                                          I-flit_core.wheel
Built wheel: dist/more_itertools-10.7.0-py3-none-any.whl                                             I-flit_core.wheel
twine check dist/*
Checking dist/more_itertools-10.7.0-py3-none-any.whl: PASSED
Checking dist/more_itertools-10.7.0.tar.gz: PASSED
```

</details>
