### PR TITLE
Use python instead of python3 when running tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ more-itertools/more-itertools#XXXX
 <!-- Describe what your PR adds, fixes, or changes here -->
 
 ### Checks and tests
-<!-- Please run `make all-checks` to help make sure your branch meets the standards enforced by GitHub Actions. -->
+<!-- Please create and activate a virtual environment and then run `make all-checks` to ensure sure your branch meets the standards enforced by GitHub Actions. -->

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all-checks: requirements coverage check docs package
 
 .PHONY: requirements
 requirements:
-	python3 -m pip install -r requirements/development.txt
-	python3 -m pip install --editable .
+	python -m pip install -r requirements/development.txt
+	python -m pip install --editable .
 
 .PHONY: check
 check:
@@ -23,7 +23,7 @@ coverage:
 
 .PHONY: test
 test:
-	python3 -m unittest -v ${tests}
+	python -m unittest -v ${tests}
 
 .PHONY: docs
 docs:


### PR DESCRIPTION
### Issue reference
Closes #1047

### Changes
Instructs the user to create a virtual environment to run tests in, and changes the Makefile to call out `python` rather than `python3` which works in more virtual environments.

### Checks and tests
👍 
