### PR TITLE
Improve count_cycle()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2437,9 +2437,7 @@ def count_cycle(iterable, n=None):
     if not seq:
         return iter(())
     counter = count() if n is None else range(n)
-    return zip(
-        chain.from_iterable(map(repeat, counter, repeat(len(seq)))), cycle(seq)
-    )
+    return zip(repeat_each(counter, len(seq)), cycle(seq))
 
 
 def mark_ends(iterable):

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2433,11 +2433,13 @@ def count_cycle(iterable, n=None):
     [(0, 'A'), (0, 'B'), (1, 'A'), (1, 'B'), (2, 'A'), (2, 'B')]
 
     """
-    iterable = tuple(iterable)
-    if not iterable:
+    seq = tuple(iterable)
+    if not seq:
         return iter(())
     counter = count() if n is None else range(n)
-    return ((i, item) for i in counter for item in iterable)
+    return zip(
+        chain.from_iterable(map(repeat, counter, repeat(len(seq)))), cycle(seq)
+    )
 
 
 def mark_ends(iterable):


### PR DESCRIPTION
Prefer an iterator stack to nested generator expressions.

Baseline:
```
% python3.14 -m timeit -s 'from more_itertools import consume, count_cycle' 'consume(count_cycle(range(1000), 3))'
5000 loops, best of 5: 93 usec per loop
```

Patched:
```
% python3.14 -m timeit -s 'from more_itertools import consume, count_cycle' 'consume(count_cycle(range(1000), 3))'
10000 loops, best of 5: 36.4 usec per loop
```