### PR TITLE
Issue 1025: Add group_ordinal()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,8 @@ Python iterables.
 |                        | `roundrobin <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.roundrobin>`_,                                                                         |
 |                        | `prepend <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.prepend>`_,                                                                               |
 |                        | `value_chain <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.value_chain>`_,                                                                       |
-|                        | `partial_product <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.partial_product>`_                                                                |
+|                        | `partial_product <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.partial_product>`_,                                                               |
+|                        | `group_ordinal <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.group_ordinal>`_                                                                    |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Summarizing            | `ilen <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.ilen>`_,                                                                                     |
 |                        | `unique_to_each <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.unique_to_each>`_,                                                                 |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,6 +115,7 @@ These tools combine multiple iterables.
 **New itertools**
 
 .. autofunction:: collapse
+.. autofunction:: group_ordinal
 .. autofunction:: interleave
 .. autofunction:: interleave_longest
 .. autofunction:: interleave_evenly

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -97,6 +97,7 @@ __all__ = [
     'filter_map',
     'first',
     'gray_product',
+    'group_ordinal',
     'groupby_transform',
     'ichunked',
     'iequals',
@@ -5301,3 +5302,25 @@ def extract(iterable, indices):
         while next_to_emit in buffer:
             yield buffer.pop(next_to_emit)
             next_to_emit += 1
+
+
+def group_ordinal(*iterables):
+    """Group elements of iterables by their ordinal.
+
+        >>> iterables = (1, 2, 3), [4, 5, 6, 7], {8}
+        >>> list(group_ordinal(*iterables))
+        [(1, 4, 8), (2, 5), (3, 6), (7,)]
+
+    The elements are grouped in the same order as their iterables.
+    """
+    iterators = list(map(iter, reversed(iterables)))
+    result = []
+    while iterators:
+        result.clear()
+        for i in reversed(range(len(iterators))):
+            try:
+                result.append(next(iterators[i]))
+            except StopIteration:
+                del iterators[i]
+        if result:
+            yield tuple(result)

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -66,6 +66,7 @@ __all__ = [
     'filter_map',
     'first',
     'gray_product',
+    'group_ordinal',
     'groupby_transform',
     'ichunked',
     'iequals',
@@ -947,3 +948,6 @@ def argmax(
 def extract(
     iterable: Iterable[_T], indices: Iterable[int]
 ) -> Iterator[_T]: ...
+def group_ordinal(
+    iterables: Iterable[Iterable[_T]]
+) -> Iterator[Tuple[_T]]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6418,3 +6418,22 @@ class ExtractTests(TestCase):
         self.assertEqual(
             list(extract(count(), [5, 7, 3, 9, 4])), [5, 7, 3, 9, 4]
         )
+
+
+class GroupOrdinalTests(TestCase):
+    def test_basic(self):
+        iterables = (
+            (1, 2, 3),
+            [4, 5, 6, 7],
+            {8}
+        )
+        expected = [
+            (1, 4, 8),
+            (2, 5),
+            (3, 6),
+            (7,)
+        ]
+        self.assertEqual(list(mi.group_ordinal(*iterables)), expected)
+
+    def test_empty(self):
+        self.assertEqual(list(mi.group_ordinal()), [])


### PR DESCRIPTION
### Issue reference
Issue #1025 zip_var: Renamed as `group_ordinal`.
Original proposal (`zip_var`) was deferred, but I thought it might have a chance renamed to `group_ordinal` as suggested by @rhettinger.

### Changes
Add `group_ordinal()`.

### Checks and tests
✅