### PR TITLE
islice_extended: Reduce memory consumption peak by 2/3

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2612,20 +2612,6 @@ class islice_extended:
         raise TypeError('islice_extended.__getitem__ argument must be a slice')
 
 
-class IteratorCounterWrapper:
-    def __init__(self, iterator):
-        self._iterator = iterator
-        self.count = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        next_element = next(self._iterator)
-        self.count += 1
-        return next_element
-
-
 def _islice_helper(it, s):
     start = s.start
     stop = s.stop
@@ -2638,9 +2624,9 @@ def _islice_helper(it, s):
 
         if start < 0:
             # Consume all but the last -start items
-            wrapper = IteratorCounterWrapper(it)
+            wrapper = countable(it)
             cache = deque(wrapper, maxlen=-start)
-            len_iter = wrapper.count
+            len_iter = wrapper.items_seen
 
             # Adjust start to be positive
             i = max(len_iter + start, 0)
@@ -2694,9 +2680,9 @@ def _islice_helper(it, s):
         if (stop is not None) and (stop < 0):
             # Consume all but the last items
             n = -stop - 1
-            wrapper = IteratorCounterWrapper(it)
+            wrapper = countable(it)
             cache = deque(wrapper, maxlen=n)
-            len_iter = wrapper.count
+            len_iter = wrapper.items_seen
 
             # If start and stop are both negative they are comparable and
             # we can just slice. Otherwise we can adjust start to be negative


### PR DESCRIPTION

### Issue reference
more-itertools/more-itertools#1019

### Changes
When (`step>0` and `start<0`) or (`step<0` and `stop<0`)

Instead of only storing the iterated elements, we store a tuple with the index of the element and the element, in order to also get the length of the iterable (see pattern `cache[-1][0]` [here](https://github.com/more-itertools/more-itertools/blob/599c0e7293b1321295f69b2bb41a27112d2ce7af/more_itertools/more.py#L2616) and [here](https://github.com/more-itertools/more-itertools/blob/599c0e7293b1321295f69b2bb41a27112d2ce7af/more_itertools/more.py#L2666)).
Leading up to a significant memory increase (+200%), if the iterated elements are small (Ex: int).

In `islice_extended`, we're replacing the following pattern:

```python
cache = deque(enumerate(range(10000000), 1), maxlen=10000000)
len_iter = cache[-1][0] if cache else 0
```
By
```python
wrappedIterator = IteratorCounterWrapper(iter(range(10000000)))
cache = deque(wrappedIterator, maxlen=50000000)
len_iter = wrappedIterator.count
```
With the use of this helper class:
```python
class IteratorCounterWrapper:
    def __init__(self, iterator: Iterator):
        self._iterator = iterator
        self.count = 0

    def __iter__(self):
        return self

    def __next__(self):
        next_element = next(self._iterator)
        self.count += 1
        return next_element
```

#### Memory Peak Impact

Tested with an iterable of 10M integers. Measurement performed with [Memray](https://github.com/bloomberg/memray).

Impacted cases are improved.<br>
*When (`step>0` and `start<0`) or (`step<0` and `stop<0`)*

| `start`,`stop`,`step` sign<br>(`n`egative or `p`ositive) | Slice | Before | After |
|-------|--------|-------|-------|
| `nnp` | [-10000000:-1:1]       | 🔴1.3GB | 🟢391.0 MB 🎉|
| `npp` | [-10000000:10000000:1] | 🔴1.3GB | 🟢391.0 MB 🎉|
| `pnn` | [9999999:-10000001:-1] | 🔴1.4GB | 🟢543.6 MB 🎉|
| `nnn` | [-1:-10000001:-1]      | 🔴1.4GB | 🟢543.6 MB 🎉|

Other cases are not impacted as expected:
| `start`,`stop`,`step` sign<br>(`n`egative or `p`ositive) | Slice | Before | After |
|-------|--------|-------|-------|
| `ppp` | [0:10000000:1] | 🟢~0 MB    | 🟢~0 MB    |
| `pnp` | [0:-1:1]       | 🟢~0 MB    | 🟢~0 MB    |
| `npn` | [-1:0:-1]      | 🟢473.6 MB | 🟢473.6 MB |
| `ppn` | [9999999:0:-1] | 🟢473.6 MB | 🟢473.6 MB |

#### Performance Impact
⚠️This change comes with a performance impact on small/medium iterable (<10K elements).<br>
🎉But also comes with a performance improvement on large iterable (>1M elements)

| `start`,`stop`,`step` sign<br>(`n`egative or `p`ositive) | Slicing syntax example for size=1000 | median size=10 | median size=100 | median size=1K | median size=10K | median size=100K | median size=1M | median size=10M |
|--------|----------------|-----------|-----------|-----------|------------|-----------|-------------|------------|
| `npp`  | [-1000:1000:1] | 🔴30.77% | 🔴35.88%  | 🔴31.95%  | 🟡11.93%  | ⚪-6.60%  | 🟢-16.19%  | 🟢-18.10%  |
| `nnp`  | [-1000:-1:1]   | 🔴30.77% | 🔴32.33%  | 🔴26.89%  | 🟡13.84%  | ⚪-6.12%  | 🟢-14.20%  | 🟢-14.92%  |
| `pnp`  | [0:-1:1]       | ⚪0.00%  | ⚪0.00%   | ⚪-0.15%  | ⚪-2.91%  | ⚪1.78%   | ⚪-2.46%   | ⚪0.60%    |
| `ppp`  | [0:1000:1]     | ⚪-0.01% | ⚪-2.53%  | ⚪-1.56%  | ⚪-0.13%  | ⚪0.66%   | ⚪-0.04%   | ⚪-2.01%   |
| `pnn`  | [999:-1001:-1] | 🔴30.77% | 🔴35.40%  | 🔴39.45%  | 🟡13.41%  | 🟡8.11%   | 🟢-18.54%  | 🟢-15.54%  |
| `nnn`  | [-1:-1001:-1]  | 🔴30.77% | 🔴37.84%  | 🔴40.14%  | 🟡15.08%  | 🟡15.90%  | 🟢-13.29%  | 🟢-20.39%  |
| `npn`  | [-1:0:-1]      | ⚪5.26%  | ⚪-1.10%  | ⚪-2.49%  | ⚪1.30%   | ⚪3.14%   | ⚪4.76%    | ⚪0.45%    |
| `ppn`  | [999:0:-1]     | ⚪0.00%  | ⚪-1.10%  | ⚪-4.56%  | ⚪-5.94%  | ⚪-1.10%  | ⚪-5.44%   | ⚪-0.89%   |


For reference, test performed with:
- OS: Windows 11 - 24H2 - 26100.6584
- Processor: Intel Core i7-11800H
- Python 3.13.3 - CPython

### Checks and tests
```
ruff format .\more_itertools\more.py
1 file left unchanged
```

```
python -m unittest -v 'tests.test_more.IsliceExtendedTests'
test_all (tests.test_more.IsliceExtendedTests.test_all) ... ok
test_elements_lifecycle (tests.test_more.IsliceExtendedTests.test_elements_lifecycle) ... ok
test_invalid_slice (tests.test_more.IsliceExtendedTests.test_invalid_slice) ... ok
test_slicing (tests.test_more.IsliceExtendedTests.test_slicing) ... ok
test_slicing_extensive (tests.test_more.IsliceExtendedTests.test_slicing_extensive) ... ok
test_zero_step (tests.test_more.IsliceExtendedTests.test_zero_step) ... ok
```

```
coverage report --show-missing --fail-under=99                                   
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
more_itertools\__init__.py       4      0   100%
more_itertools\more.py        1663      0   100%
more_itertools\recipes.py      357      0   100%
----------------------------------------------------------
TOTAL                         2024      0   100%
```