### PR TITLE
Fast path for count_cycle() when the output is bounded

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2410,6 +2410,8 @@ def count_cycle(iterable, n=None):
     [(0, 'A'), (0, 'B'), (1, 'A'), (1, 'B'), (2, 'A'), (2, 'B')]
 
     """
+    if n is not None:
+        return product(range(n), iterable)
     seq = tuple(iterable)
     if not seq:
         return iter(())


### PR DESCRIPTION
For the bounded case, `count_cycle()` is the same as `itertools.product`.