### PR TITLE
Add __slots__ to _concurrent_tee

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5399,6 +5399,8 @@ def concurrent_tee(iterable, n=2):
 
 
 class _concurrent_tee:
+    __slots__ = ('iterator', 'link', 'lock')
+
     def __init__(self, iterable):
         it = iter(iterable)
         if isinstance(it, _concurrent_tee):


### PR DESCRIPTION
Makes tee objects a little smaller and a little faster. Not essential but nice to have.