### PR TITLE
Introduce case-handling on the stubs for `stagger` based on the value of the `longest` argument

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import types
+
 from collections.abc import (
     Container,
     Hashable,
@@ -25,7 +26,6 @@ from typing import (
     overload,
     type_check_only,
 )
-
 from typing_extensions import Protocol
 
 __all__ = [


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
<!-- Not all proposals for new functionality will be accepted, so please save yourself some work by checking first with an issue -->
more-itertools/more-itertools#1102

### Changes
<!-- Describe what your PR adds, fixes, or changes here -->
This PR splits the two overloads for the `more_itertools.more.stagger` function into two cases each based on whether `longest = True` or `longest = False`.

- When `longest = False`, the `fill_value` argument is ignored and the return type is always the generic over the same type `_T` as the input iterable. 
- When `longest = True`, the previous behaviour is retained, i.e. the return type is generic over `_T` and the type of  `fill_value`; or `_T` and `None` if `fill_value` goes unspecified.

### Checks and tests
<!-- Please create and activate a virtual environment and then run `make all-checks` to ensure sure your branch meets the standards enforced by GitHub Actions. -->
I've run `make all-checks` successfully locally. In particular I've run

```
> stubtest more_itertools.more more_itertools.recipes
Success: no issues found in 2 modules
```
