### PR TITLE
feat: add hypercube_product sampling

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -52,7 +52,6 @@ __all__ = [
     'countable',
     'derangements',
     'dft',
-    'diagonal_product',
     'difference',
     'distinct_combinations',
     'distinct_permutations',
@@ -62,6 +61,7 @@ __all__ = [
     'duplicates_everseen',
     'duplicates_justseen',
     'classify_unique',
+    'equidistributed_product',
     'exactly_n',
     'extract',
     'filter_except',
@@ -909,8 +909,10 @@ def constrained_batches(
 def gray_product(
     *iterables: Iterable[_T], repeat: int = ...
 ) -> Iterator[tuple[_T, ...]]: ...
-def diagonal_product(
+def equidistributed_product(
     *iterables: Iterable[_T],
+    coset_stride_method: Literal["incremental", "small_coprime"],
+    iterable_stride_method: Literal["incremental", "small_coprime"],
 ) -> Iterator[tuple[_T, ...]]: ...
 def partial_product(
     *iterables: Iterable[_T], repeat: int = ...

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -52,6 +52,7 @@ __all__ = [
     'countable',
     'derangements',
     'dft',
+    'diagonal_product',
     'difference',
     'distinct_combinations',
     'distinct_permutations',
@@ -907,6 +908,9 @@ def constrained_batches(
 ) -> Iterator[tuple[_T]]: ...
 def gray_product(
     *iterables: Iterable[_T], repeat: int = ...
+) -> Iterator[tuple[_T, ...]]: ...
+def diagonal_product(
+    *iterables: Iterable[_T],
 ) -> Iterator[tuple[_T, ...]]: ...
 def partial_product(
     *iterables: Iterable[_T], repeat: int = ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6603,3 +6603,139 @@ class TestConcurrentTee(TestCase):
         with self.assertRaises(ValueError):
             non_concurrent_source = producer(limit)
             mi.concurrent_tee(non_concurrent_source, n=-1)  # Negative n
+
+
+class DiagonalProductTests(TestCase):
+    def test_diagonal_sampling(self):
+        # total space size == 10 * 5 * 2 == 100, period == 10.
+        iterables = [range(10), range(5), range(2)]
+        expected = [
+            # period 0
+            (0, 0, 0),
+            (1, 1, 1),
+            (2, 2, 0),
+            (3, 3, 1),
+            (4, 4, 0),
+            (5, 0, 1),
+            (6, 1, 0),
+            (7, 2, 1),
+            (8, 3, 0),
+            (9, 4, 1),
+            # period 1
+            (0, 0, 1),
+            (1, 1, 0),
+            (2, 2, 1),
+            (3, 3, 0),
+            (4, 4, 1),
+            (5, 0, 0),
+            (6, 1, 1),
+            (7, 2, 0),
+            (8, 3, 1),
+            (9, 4, 0),
+            # period 2
+            (0, 1, 0),
+            (1, 2, 1),
+            (2, 3, 0),
+            (3, 4, 1),
+            (4, 0, 0),
+            (5, 1, 1),
+            (6, 2, 0),
+            (7, 3, 1),
+            (8, 4, 0),
+            (9, 0, 1),
+            # period 3
+            (0, 1, 1),
+            (1, 2, 0),
+            (2, 3, 1),
+            (3, 4, 0),
+            (4, 0, 1),
+            (5, 1, 0),
+            (6, 2, 1),
+            (7, 3, 0),
+            (8, 4, 1),
+            (9, 0, 0),
+            # period 4
+            (0, 2, 0),
+            (1, 3, 1),
+            (2, 4, 0),
+            (3, 0, 1),
+            (4, 1, 0),
+            (5, 2, 1),
+            (6, 3, 0),
+            (7, 4, 1),
+            (8, 0, 0),
+            (9, 1, 1),
+            # period 5
+            (0, 2, 1),
+            (1, 3, 0),
+            (2, 4, 1),
+            (3, 0, 0),
+            (4, 1, 1),
+            (5, 2, 0),
+            (6, 3, 1),
+            (7, 4, 0),
+            (8, 0, 1),
+            (9, 1, 0),
+            # period 6
+            (0, 3, 0),
+            (1, 4, 1),
+            (2, 0, 0),
+            (3, 1, 1),
+            (4, 2, 0),
+            (5, 3, 1),
+            (6, 4, 0),
+            (7, 0, 1),
+            (8, 1, 0),
+            (9, 2, 1),
+            # period 7
+            (0, 3, 1),
+            (1, 4, 0),
+            (2, 0, 1),
+            (3, 1, 0),
+            (4, 2, 1),
+            (5, 3, 0),
+            (6, 4, 1),
+            (7, 0, 0),
+            (8, 1, 1),
+            (9, 2, 0),
+            # period 8
+            (0, 4, 0),
+            (1, 0, 1),
+            (2, 1, 0),
+            (3, 2, 1),
+            (4, 3, 0),
+            (5, 4, 1),
+            (6, 0, 0),
+            (7, 1, 1),
+            (8, 2, 0),
+            (9, 3, 1),
+            # period 9
+            (0, 4, 1),
+            (1, 0, 0),
+            (2, 1, 1),
+            (3, 2, 0),
+            (4, 3, 1),
+            (5, 4, 0),
+            (6, 0, 1),
+            (7, 1, 0),
+            (8, 2, 1),
+            (9, 3, 0),
+        ]
+        actual = list(mi.diagonal_product(*iterables))
+        # only unique elements are yielded
+        assert len(set(actual)) == len(actual)
+        self.assertEqual(actual, expected)
+
+    def test_diagonal_sampling_maximally_explorative(self):
+        iterables = [range(10), range(5), range(2)]
+
+        n_samples_per_element = 5
+
+        samples = mi.diagonal_product(*iterables)
+        first_50_samples = islice(samples, n_samples_per_element * 10)
+
+        for sampled_elements in zip(*first_50_samples):
+            counts = Counter(sampled_elements)
+            for number in counts.values():
+                # sampled each iterable element at least 5 times in 50 samples.
+                assert number >= n_samples_per_element


### PR DESCRIPTION
### Issue reference
(Issue reference)
[more-itertools/more-itertools#XXXX](https://github.com/more-itertools/more-itertools/issues/1113)

### Changes

This PR adds a minimal implementation for hypercube sampling products of a Cartesian product space in a maximally explorative way by sampling from the diagonal of the Cartesian product hypercube. 

See issue linked for more details. 

Looking back at `itertools.product` they do state that the elements will be held in memory (as they are here) so I could always do `sequences = tuple(map(tuple, iterables))` as the first step and proceed now knowing the sizes of all the finite iterables from there, but this current implementation doesn't require eager consumption of each iterable immediately. 

Depends what y'all think is most readable / preferable, lmk!

### Checks and tests
✅ 
