### PR TITLE
Minor tweak to conconcurrent_tee

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5425,13 +5425,12 @@ class _concurrent_tee:
     __slots__ = ('iterator', 'link', 'lock')
 
     def __init__(self, iterable):
-        it = iter(iterable)
-        if isinstance(it, _concurrent_tee):
-            self.iterator = it.iterator
-            self.link = it.link
-            self.lock = it.lock
+        if isinstance(iterable, _concurrent_tee):
+            self.iterator = iterable.iterator
+            self.link = iterable.link
+            self.lock = iterable.lock
         else:
-            self.iterator = it
+            self.iterator = iter(iterable)
             self.link = [None, None]
             self.lock = Lock()
 


### PR DESCRIPTION
When the input is a `_concurrent_tee` object, an unnecessary call to `iter` was being made.  Removing the extra step simplifies the code and gives a minor speed-up for instantiation.