### PR TITLE
Issue 895: Warnings for files in with_iter

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -563,6 +563,8 @@ def with_iter(context_manager):
 
         upper_lines = (line.upper() for line in with_iter(open('foo')))
 
+    Note that you have to actually exhaust the iterator for opened files to be closed.
+
     Any context manager which returns an iterable is a candidate for
     ``with_iter``.
 


### PR DESCRIPTION
Adds a note to `with_iter`'s documentation about closing files.

Closes #895