### PR TITLE
Fast path for difference() when *initial* is specified

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2829,7 +2829,7 @@ def difference(iterable, func=sub, *, initial=None):
         return iter([])
 
     if initial is not None:
-        first = []
+        return map(func, b, a)
 
     return chain(first, map(func, b, a))
 


### PR DESCRIPTION
The chain wrapper is unnecessary when *initial* is specified. It only adds overhead.