### PR TITLE
Add sized_iterator class

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -280,6 +280,7 @@ consume iterables.
 .. autoclass:: callback_iter
 .. autofunction:: countable
 .. autofunction:: consumer
+.. autoclass:: sized_iterator
 .. autofunction:: with_iter
 
 ----

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -148,6 +148,7 @@ __all__ = [
     'serialize',
     'set_partitions',
     'side_effect',
+    'sized_iterator',
     'sliced',
     'sort_together',
     'split_after',
@@ -570,6 +571,39 @@ def with_iter(context_manager):
     """
     with context_manager as iterable:
         yield from iterable
+
+
+class sized_iterator:
+    """Wrap *iterable* with an iterator that also implements ``__len__``.
+
+    This is useful when the length of an iterable is known in advance but
+    not supported by the iterable itself (e.g., a generator). This allows
+    usage with tools that rely on ``len()``, such as progress bars.
+
+        >>> def my_generator(n):
+        ...     for i in range(n):
+        ...         yield f"Item{i}"
+        >>> gen = my_generator(3)
+        >>> sized_gen = sized_iterator(gen, 3)
+        >>> len(sized_gen)
+        3
+        >>> list(sized_gen)
+        ['Item0', 'Item1', 'Item2']
+
+    """
+
+    def __init__(self, iterable, length):
+        self._iterator = iter(iterable)
+        self._length = length
+
+    def __next__(self):
+        return next(self._iterator)
+
+    def __iter__(self):
+        return self
+
+    def __len__(self):
+        return self._length
 
 
 def one(iterable, too_short=None, too_long=None):

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -120,6 +120,7 @@ __all__ = [
     'serialize',
     'set_partitions',
     'side_effect',
+    'sized_iterator',
     'sliced',
     'sort_together',
     'split_after',
@@ -210,6 +211,13 @@ def iterate(func: Callable[[_T], _T], start: _T) -> Iterator[_T]: ...
 def with_iter(
     context_manager: AbstractContextManager[Iterable[_T]],
 ) -> Iterator[_T]: ...
+
+class sized_iterator(Generic[_T], Iterator[_T], Sized):
+    def __init__(self, iterable: Iterable[_T], length: int) -> None: ...
+    def __next__(self) -> _T: ...
+    def __iter__(self) -> sized_iterator[_T]: ...
+    def __len__(self) -> int: ...
+
 def one(
     iterable: Iterable[_T],
     too_short: _Raisable | None = ...,

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -706,6 +706,17 @@ class WithIterTests(TestCase):
         self.assertTrue(s.closed)
 
 
+class SizedIteratorTests(TestCase):
+    def test_sized_iterator(self):
+        gen = (x for x in range(3))
+        sized_gen = mi.sized_iterator(gen, 3)
+
+        # The sized_generator should have the correct length
+        self.assertEqual(len(sized_gen), 3)
+        # The sized_generator elements should be the same as the original
+        self.assertListEqual(list(sized_gen), list(range(3)))
+
+
 class OneTests(TestCase):
     def test_basic(self):
         it = iter(['item'])


### PR DESCRIPTION
### Issue reference
[more-itertools/more-itertools#1123](https://github.com/more-itertools/more-itertools/issues/1123)

### Changes
Adds a `sized_iterator` class that wraps around an _iterable_ and provides a `__len__` function for it.

This is useful when the length of an _iterable_ is known in advance but not supported by the iterable itself (e.g., a generator, a file, a database). This allows usage with tools that rely on ``len()``, such as progress bars.

```
>>> def my_generator(n):
...     for i in range(n):
...         yield f"Item{i}"
>>> gen = my_generator(3)
>>> sized_gen = sized_iterator(gen, 3)
>>> len(sized_gen)
3
>>> list(sized_gen)
['Item0', 'Item1', 'Item2']
```

### Checks and tests
- [X] check
- [X] coverage
- [X] docs
- [X] package