### PR TITLE
Major wishlist: Issue #1057: Raise exception for invalid size in windowed()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1045,11 +1045,8 @@ def windowed(seq, n, fillvalue=None, step=1):
         >>> list(windowed(chain(padding, iterable), 3))
         [(None, None, 1), (None, 1, 2), (1, 2, 3), (2, 3, 4)]
     """
-    if n < 0:
-        raise ValueError('n must be >= 0')
-    if n == 0:
-        yield ()
-        return
+    if n <= 0:
+        raise ValueError('n must be > 0')
     if step < 1:
         raise ValueError('step must be >= 1')
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -829,7 +829,6 @@ class WindowedTests(TestCase):
             (3, [(1, 2, 3), (2, 3, 4), (3, 4, 5)]),
             (2, [(1, 2), (2, 3), (3, 4), (4, 5)]),
             (1, [(1,), (2,), (3,), (4,), (5,)]),
-            (0, [()]),
         ):
             with self.subTest(n=n):
                 actual = list(mi.windowed(iterable, n))
@@ -865,9 +864,11 @@ class WindowedTests(TestCase):
         expected = [(1, 2, 3), (4, 5, '!')]
         self.assertEqual(actual, expected)
 
-    def test_negative(self):
+    def test_invalid_n(self):
         with self.assertRaises(ValueError):
-            list(mi.windowed([1, 2, 3, 4, 5], -1))
+            list(mi.windowed([1, 2, 3, 4, 5], 0))  # n is zero
+        with self.assertRaises(ValueError):
+            list(mi.windowed([1, 2, 3, 4, 5], -1))  # n is negative
 
     def test_empty_seq(self):
         actual = list(mi.windowed([], 3))


### PR DESCRIPTION
For #1057, suggest raising a `ValueError` for `n == 0`, making it consistent with `batched` and `sliding_window`. 

The OP and some of the respondents prefer returning `len(xs) + 1` empty tuples because 
`windowed(xs, n)` always has length `len(xs) - n + 1`. While the sizes match, I don't see how that would be a useful result. Unlike other values of `n`, the input cannot be reconstructed from the output because no data would get through.  Another possibility is to return an empty iterator like `grouper` does.  I prefer the `ValueError` because it is most likely a user error and because `n == 0` otherwise isn't obvious about what it should do. If someone is already using `n = 0`, then any change would break their code, so a `ValueError` would be a better flag than just giving a different andunexpected output.