### PR TITLE
Minor cleanups

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,5 @@ include docs/Makefile
 include docs/make.bat
 include docs/conf.py
 include docs/_static/*
-include fabfile.py
 include tox.ini
 include tests/*.py

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all-checks: requirements coverage check docs package
 
 .PHONY: requirements
 requirements:
-	python -m pip install -r requirements/development.txt
+	python -m pip install --upgrade -r requirements/development.txt
 	python -m pip install --editable .
 
 .PHONY: check
@@ -18,7 +18,7 @@ format:
 
 .PHONY: coverage
 coverage:
-	python -m pip install -r requirements/testing.txt
+	python -m pip install --upgrade -r requirements/testing.txt
 	coverage run --include="more_itertools/*.py" -m unittest
 	coverage report --show-missing --fail-under=99
 
@@ -28,11 +28,11 @@ test:
 
 .PHONY: docs
 docs:
-	python -m pip install -r docs/requirements.txt
+	python -m pip install --upgrade -r docs/requirements.txt
 	sphinx-build -W -b html docs docs/_build/html
 
 .PHONY: package
 package:
-	python -m pip install -r requirements/packaging.txt
+	python -m pip install --upgrade -r requirements/packaging.txt
 	flit build --setup-py
 	twine check dist/*

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,7 @@ Python iterables.
 |                        | `unzip <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.unzip>`_,                                                                                   |
 |                        | `batched <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.batched>`_,                                                                               |
 |                        | `grouper <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.grouper>`_,                                                                               |
-|                        | `partition <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.partition>`_,                                                                           |
-|                        | `transpose <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.transpose>`_                                                                            |
+|                        | `partition <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.partition>`_                                                                            |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Lookahead and lookback | `spy <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.spy>`_,                                                                                       |
 |                        | `peekable <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.peekable>`_,                                                                             |
@@ -127,7 +126,9 @@ Python iterables.
 |                        | `polynomial_from_roots <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.polynomial_from_roots>`_,                                                   |
 |                        | `polynomial_derivative <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.polynomial_derivative>`_,                                                   |
 |                        | `polynomial_eval <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.polynomial_eval>`_,                                                               |
-|                        | `sum_of_squares <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.sum_of_squares>`_                                                                  |
+|                        | `reshape <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.reshape>`_,                                                                               |
+|                        | `sum_of_squares <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.sum_of_squares>`_,                                                                 |
+|                        | `transpose <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.transpose>`_                                                                            |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Integer math           | `factor <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.factor>`_,                                                                                 |
 |                        | `is_prime <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.is_prime>`_,                                                                             |
@@ -193,7 +194,6 @@ Python iterables.
 |                        | `consume <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.consume>`_,                                                                               |
 |                        | `tabulate <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.tabulate>`_,                                                                             |
 |                        | `repeatfunc <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.repeatfunc>`_,                                                                         |
-|                        | `reshape <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.reshape>`_,                                                                               |
 |                        | `doublestarmap <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.doublestarmap>`_                                                                    |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
Minor cleanups:

* In README.rst, move `transpose` and `reshape` to the `math` section. Ideally these matrix operations would be in the same category as `matmul` and `dotproduct`.

* In MANIFEST.in, remove `fabfile.py`.

* In Makefile, add `-U` to various pip installs for `development.txt`, `testing.txt`, `docs/requirements.txt`, and `packaging.txt`. That would have helped when my local `ruff` was older than the one used in the Github testing build environment.