### PR TITLE
Version 11.0.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Python iterables.
 |                        | `substrings_indexes <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.substrings_indexes>`_,                                                         |
 |                        | `stagger <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.stagger>`_,                                                                               |
 |                        | `windowed_complete <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.windowed_complete>`_,                                                           |
+|                        | `pairwise <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.pairwise>`_,                                                                             |
 |                        | `triplewise <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.triplewise>`_,                                                                         |
 |                        | `sliding_window <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.sliding_window>`_,                                                                 |
 |                        | `subslices <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.subslices>`_                                                                            |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,6 +72,7 @@ These tools yield windows of items from an iterable.
 
 **Itertools recipes**
 
+.. autofunction:: pairwise
 .. autofunction:: triplewise
 .. autofunction:: sliding_window
 .. autofunction:: subslices

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,6 +5,14 @@ Version History
 .. automodule:: more_itertools
    :noindex:
 
+11.0.1
+------
+
+* Updates
+    * This release restores :func:`pairwise`, which was mistakenly removed in 11.0.0
+      instead of being deprecated. It is now marked as deprecated and will be removed
+      in a future major release. Use :func:`itertools.pairwise` as a replacement.
+
 11.0.0
 ------
 
@@ -40,7 +48,7 @@ Version History
     * The type hints for :func:`always_iterable` were improved (thanks to rhettinger and maltevesper)
     * A potential bug in :func:`callback_iter` was fixed
     * A bug in :func:`exactly_n`'s handling of negative arguments was fixed (thanks to rhettinger)
-    * :func:`extract`` now accepts a `monotonic` argument for improved performance (thanks to rhettinger)
+    * :func:`extract` now accepts a `monotonic` argument for improved performance (thanks to rhettinger)
     * A bug in :func:`numeric_range`'s handling of negative steps was fixed (thanks to bysiber)
     * :func:`grouper` implementation was updated to match the ``itertools`` docs (thanks to rhettinger)
     * :func:`nth_product`, :func:`product_index`, :func:`gray_product`,

--- a/more_itertools/__init__.py
+++ b/more_itertools/__init__.py
@@ -3,4 +3,4 @@
 from .more import *  # noqa
 from .recipes import *  # noqa
 
-__version__ = '11.0.0'
+__version__ = '11.0.1'

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -25,7 +25,7 @@ from itertools import (
     filterfalse,
     groupby,
     islice,
-    pairwise,
+    pairwise as itertools_pairwise,
     product,
     repeat,
     starmap,
@@ -60,6 +60,7 @@ __all__ = [
     'nth_combination',
     'padnone',
     'pad_none',
+    'pairwise',
     'partition',
     'polynomial_eval',
     'polynomial_from_roots',
@@ -327,6 +328,13 @@ def repeatfunc(function, times=None, *args):
     if times is None:
         return starmap(function, repeat(args))
     return starmap(function, repeat(args, times))
+
+
+def pairwise(iterable):
+    return itertools_pairwise(iterable)
+
+
+pairwise.__doc__ = itertools_pairwise.__doc__
 
 
 def grouper(iterable, n, incomplete='fill', fillvalue=None):

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -331,10 +331,15 @@ def repeatfunc(function, times=None, *args):
 
 
 def pairwise(iterable):
+    """
+    Wrapper for :func:`itertools.pairwise`.
+
+    .. warning::
+
+       This function is deprecated as of version 11.0.0. It will be removed in a future
+       major release.
+    """
     return itertools_pairwise(iterable)
-
-
-pairwise.__doc__ = itertools_pairwise.__doc__
 
 
 def grouper(iterable, n, incomplete='fill', fillvalue=None):

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -34,6 +34,7 @@ __all__ = [
     'nth_combination',
     'padnone',
     'pad_none',
+    'pairwise',
     'partition',
     'polynomial_eval',
     'polynomial_from_roots',
@@ -97,6 +98,7 @@ def flatten(list_of_lists: Iterable[Iterable[_T]]) -> Iterator[_T]: ...
 def repeatfunc(
     function: Callable[..., _U], times: int | None = ..., *args: Any
 ) -> Iterator[_U]: ...
+def pairwise(iterable: Iterable[_T]) -> Iterator[tuple[_T, _T]]: ...
 def grouper(
     iterable: Iterable[_T],
     n: int,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.0.0
+current_version = 11.0.1
 commit = True
 tag = False
 files = more_itertools/__init__.py

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -9,7 +9,6 @@ from itertools import (
     groupby,
     permutations,
     islice,
-    pairwise,
 )
 from operator import mul, eq
 from math import comb, prod, factorial
@@ -1631,7 +1630,7 @@ class RunningMedianTests(TestCase):
 
         # Window size of 2 is a moving average of pairs
         data = random.choices(range(-500, 500), k=500)
-        expected = list(map(mean, pairwise(data)))
+        expected = list(map(mean, mi.pairwise(data)))
         actual = list(islice(running_median(data, maxlen=2), 1, None))
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
This PR has changes for 11.0.1. The `pairwise` function is restored and marked as deprecated. 

Closes https://github.com/more-itertools/more-itertools/issues/1141