### PR TITLE
Proposed fix to #1143

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -451,12 +451,17 @@ def always_iterable(
 ) -> Iterator[bytes]: ...
 @overload
 def always_iterable(
-    obj: Iterable[_T],
+    obj: str,
+    base_type: type[str] | tuple[type[str], type[bytes]] = ...,
+) -> Iterator[str]: ...
+@overload
+def always_iterable(
+    obj: Iterable[_T] | None,
     base_type: type[bytes] | type[str] | tuple[type[str], type[bytes]] = ...,
 ) -> Iterator[_T]: ...
 @overload
 def always_iterable(
-    obj: _T, base_type: tuple[type[str], type[bytes]] = ...
+    obj: _T | None, base_type: tuple[type[str], type[bytes]] = ...
 ) -> Iterator[_T]: ...
 @overload
 def always_iterable(


### PR DESCRIPTION
Avoids the bad unioning while keeping the other results the same.

This fixes the optional-input inference regression from #1143 (the setuptools report), while preserving the existing `always_iterable` reveal types established for #1032 cases such as None, scalars, bytes, str, and ordinary iterables.

**Explanation of the core problem and the solution**: When there are two overloads, say `T` and `None` and the caller passes `T | None`, instead of getting a nice merged result, the type checker forms a union of the return types. The simplest fix is to add an overload that handles the union directly and returns the cleaner type that matches the actual runtime behavior.