### PR TITLE
docs: fix typo and improve running_statistics docstring

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -5549,6 +5549,19 @@ def running_max(iterable, *, maxlen=None):
 
 @dataclass(frozen=True, slots=True)
 class Stats:
+    """Dataclass holding summary statistics for a window of numeric values.
+
+    Returned by :func:`running_statistics`.
+
+    Fields:
+
+    - *size*: number of values in the current window
+    - *minimum*: smallest value in the current window
+    - *median*: median value in the current window
+    - *maximum*: largest value in the current window
+    - *mean*: arithmetic mean of the current window
+    """
+
     size: int
     minimum: float
     median: float
@@ -5563,8 +5576,20 @@ def running_statistics(iterable, *, maxlen=None):
     of the sliding window.  The default of *None* is equivalent to
     an unbounded window.
 
-    Yields instances of a ``Stats`` dataclass with fields for the dataset *size*,
-    *mininum* value, *median* value, *maximum* value, and the arithmetic *mean*.
+    Yields instances of the ``Stats`` dataclass with fields for the dataset
+    *size*, *minimum* value, *median* value, *maximum* value, and the
+    arithmetic *mean*.
+
+    For example:
+
+        >>> from more_itertools import running_statistics
+        >>> stats = list(running_statistics([4, 3, 7, 0, 8]))
+        >>> [s.minimum for s in stats]
+        [4, 3, 3, 0, 0]
+        >>> [s.maximum for s in stats]
+        [4, 4, 7, 7, 8]
+        >>> [s.mean for s in stats]
+        [4.0, 3.5, 4.666666666666667, 3.5, 4.4]
 
     Supports numeric types such as int, float, Decimal, and Fraction,
     but not complex numbers which are unorderable.


### PR DESCRIPTION
### Issue reference
<!-- If you're adding a new feature, please make an issue first -->
<!-- If you're fixing a trivial bug (e.g. a typo) you need not make an issue first -->
<!-- If you're fixing a non-trivial bug, please go ahead and make an issue first -->
<!-- Not all proposals for new functionality will be accepted, so please save yourself some work by checking first with an issue -->
N/A — documentation-only fix

### Changes

- Fix typo `*mininum*` → `*minimum*` in the `running_statistics` docstring
- Add a usage example to `running_statistics` consistent with the style used in `running_min` and `running_max`
- Add a docstring to the `Stats` dataclass describing each of its fields

### Checks and tests
<!-- Please create and activate a virtual environment and then run `make all-checks` to ensure sure your branch meets the standards enforced by GitHub Actions. -->
- All existing doctests pass (`python3 -c "import doctest, more_itertools.more; r = doctest.testmod(more_itertools.more); print(r)"` → `TestResults(failed=0, attempted=582)`)
- Python syntax verified with `python3 -m py_compile`
- No logic, tests, or behaviour changed — documentation only