### PR TITLE
Revert "Issue 1032: Improve common case typehints for always_iterable"

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import types
 
 from collections.abc import (
@@ -170,7 +171,11 @@ _GenFn = TypeVar('_GenFn', bound=Callable[..., Iterator[Any]])
 _Raisable = BaseException | type[BaseException]
 _NumberT = TypeVar("_NumberT", float, Decimal, Fraction)
 
-_ClassInfo = type | types.UnionType | tuple[_ClassInfo, ...]
+# The type of isinstance's second argument (from typeshed builtins)
+if sys.version_info >= (3, 10):
+    _ClassInfo = type | types.UnionType | tuple[_ClassInfo, ...]
+else:
+    _ClassInfo = type | tuple[_ClassInfo, ...]
 
 @type_check_only
 class _SizedIterable(Protocol[_T_co], Sized, Iterable[_T_co]): ...
@@ -435,30 +440,6 @@ def sort_together(
 ) -> list[tuple[_T, ...]]: ...
 def unzip(iterable: Iterable[Sequence[_T]]) -> tuple[Iterator[_T], ...]: ...
 def divide(n: int, iterable: Iterable[_T]) -> list[Iterator[_T]]: ...
-@overload
-def always_iterable(
-    obj: None, base_type: Any = ...
-) -> Iterator[tuple[()]]: ...
-@overload
-def always_iterable(obj: bytes, base_type: None) -> Iterator[int]: ...
-@overload
-def always_iterable(obj: Iterable[_T], base_type: None) -> Iterator[_T]: ...
-@overload
-def always_iterable(obj: _T, base_type: None) -> Iterator[_T]: ...
-@overload
-def always_iterable(
-    obj: bytes, base_type: type[bytes] | tuple[type[str], type[bytes]] = ...
-) -> Iterator[bytes]: ...
-@overload
-def always_iterable(
-    obj: Iterable[_T],
-    base_type: type[bytes] | type[str] | tuple[type[str], type[bytes]] = ...,
-) -> Iterator[_T]: ...
-@overload
-def always_iterable(
-    obj: _T, base_type: tuple[type[str], type[bytes]] = ...
-) -> Iterator[_T]: ...
-@overload
 def always_iterable(
     obj: object,
     base_type: _ClassInfo | None = ...,


### PR DESCRIPTION
This PR reverts more-itertools/more-itertools#1107 - we're declaring defeat on making `@overload` type hints for `always_iterable`. The function is too magical for type checking systems to handle.

Closes #1143