### PR TITLE
Changes for version 11.0.2

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -338,22 +338,15 @@ The tools focus on math with integers.
 Statistics
 ==========
 
-**New itertools**
+**Itertools recipes**
 
 The tools focus on simple statistics.
 
-----
-
 .. autofunction:: running_min
 .. autofunction:: running_max
-.. autofunction:: running_statistics
-
-----
-
-**Itertools recipes**
-
 .. autofunction:: running_mean
 .. autofunction:: running_median
+.. autofunction:: running_statistics
 
 
 Others

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -14,7 +14,9 @@ Version History
     * :func:`zip_equal` was removed in 11.0.0. It had been deprecated and raising ``DeprecationWarning``
       since 2021, but it's removal should have been documented in 11.0.0's release notes.
       We regret the error.
-    * The docstring for :func:`running_statistics` was improved (thanks to mastash3ff)
+    * :func:`running_statistics` has been moved from ``more_itertools.more`` to
+      ``more_itertools.recipes``. Its docstring was also improved (thanks to mastash3ff
+      and rhettinger)
 
 11.0.1
 ------

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,6 +5,17 @@ Version History
 .. automodule:: more_itertools
    :noindex:
 
+11.0.2
+------
+
+* Updates
+    * The changes to the type hints for :func:`always_iterable` in 11.0.0 have been
+      reverted due to reported problems (thanks to ngoldbaum and rhettinger)
+    * :func:`zip_equal` was removed in 11.0.0. It had been deprecated and raising ``DeprecationWarning``
+      since 2021, but it's removal should have been documented in 11.0.0's release notes.
+      We regret the error.
+    * The docstring for :func:`running_statistics` was improved (thanks to mastash3ff)
+
 11.0.1
 ------
 
@@ -18,6 +29,8 @@ Version History
 
 * Potentially breaking changes
     * Python 3.9 support was dropped, since it went EOL on 2025-10-31
+    * :func:`zip_equal` was removed. Applications should use the standard library
+      function :func:`zip` with ``strict=True`` as a replacement.
     * :func:`callback_iter` is deprecated. It will be removed in a future major release.
     * :func:`iequals` no longer returns ``True`` when called with ``([], [ANY])`` (thanks to rhettinger and pochmann3)
     * The ``pred`` argument for :func:`locate` and :func:`replace` must now be able to

--- a/more_itertools/__init__.py
+++ b/more_itertools/__init__.py
@@ -3,4 +3,4 @@
 from .more import *  # noqa
 from .recipes import *  # noqa
 
-__version__ = '11.0.1'
+__version__ = '11.0.2'

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3,11 +3,9 @@ import math
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
 from contextlib import suppress
-from dataclasses import dataclass
 from functools import cached_property, partial, wraps
 from heapq import heapify, heapreplace
 from itertools import (
-    accumulate,
     chain,
     combinations,
     compress,
@@ -50,8 +48,6 @@ from .recipes import (
     is_prime,
     nth,
     powerset,
-    running_mean,
-    running_median,
     sieve,
     take,
     unique_everseen,
@@ -62,7 +58,6 @@ from .recipes import (
 __all__ = [
     'AbortThread',
     'SequenceView',
-    'Stats',
     'adjacent',
     'all_unique',
     'always_iterable',
@@ -148,9 +143,6 @@ __all__ = [
     'rlocate',
     'rstrip',
     'run_length',
-    'running_min',
-    'running_max',
-    'running_statistics',
     'sample',
     'seekable',
     'serialize',
@@ -5463,121 +5455,3 @@ class _concurrent_tee:
                     link[1] = [None, None]
         value, self.link = link
         return value
-
-
-def _windowed_running_min(iterator, maxlen):
-    sis = deque()  # Strictly increasing subsequence
-    for index, value in enumerate(iterator):
-        if sis and sis[0][0] == index - maxlen:
-            sis.popleft()
-        while sis and not sis[-1][1] < value:  # Remove non-increasing values
-            sis.pop()
-        sis.append((index, value))  # Most recent value at position -1
-        yield sis[0][1]  # Window minimum at position 0
-
-
-def running_min(iterable, *, maxlen=None):
-    """Smallest of values seen so far or values in a sliding window.
-
-    Set *maxlen* to a positive integer to specify the maximum size
-    of the sliding window.  The default of *None* is equivalent to
-    an unbounded window.
-
-    For example:
-
-        >>> list(running_min([4, 3, 7, 0, 8, 1, 6, 2, 9, 5]))
-        [4, 3, 3, 0, 0, 0, 0, 0, 0, 0]
-
-        >>> list(running_min([4, 3, 7, 0, 8, 1, 6, 2, 9, 5], maxlen=3))
-        [4, 3, 3, 0, 0, 0, 1, 1, 2, 2]
-
-    Supports numeric types such as int, float, Decimal, and Fraction,
-    but not complex numbers which are unorderable.
-    """
-
-    iterator = iter(iterable)
-
-    if maxlen is None:
-        return accumulate(iterator, func=min)
-
-    if maxlen <= 0:
-        raise ValueError('Window size should be positive')
-
-    return _windowed_running_min(iterator, maxlen)
-
-
-def _windowed_running_max(iterator, maxlen):
-    sds = deque()  # Strictly decreasing subsequence
-    for index, value in enumerate(iterator):
-        if sds and sds[0][0] == index - maxlen:
-            sds.popleft()
-        while sds and not sds[-1][1] > value:  # Remove non-decreasing values
-            sds.pop()
-        sds.append((index, value))  # Most recent value at position -1
-        yield sds[0][1]  # Window maximum at position 0
-
-
-def running_max(iterable, *, maxlen=None):
-    """Largest of values seen so far or values in a sliding window.
-
-    Set *maxlen* to a positive integer to specify the maximum size
-    of the sliding window.  The default of *None* is equivalent to
-    an unbounded window.
-
-    For example:
-
-        >>> list(running_max([4, 3, 7, 0, 8, 1, 6, 2, 9, 5]))
-        [4, 4, 7, 7, 8, 8, 8, 8, 9, 9]
-
-        >>> list(running_max([4, 3, 7, 0, 8, 1, 6, 2, 9, 5], maxlen=3))
-        [4, 4, 7, 7, 8, 8, 8, 6, 9, 9]
-
-    Supports numeric types such as int, float, Decimal, and Fraction,
-    but not complex numbers which are unorderable.
-    """
-
-    iterator = iter(iterable)
-
-    if maxlen is None:
-        return accumulate(iterator, func=max)
-
-    if maxlen <= 0:
-        raise ValueError('Window size should be positive')
-
-    return _windowed_running_max(iterator, maxlen)
-
-
-@dataclass(frozen=True, slots=True)
-class Stats:
-    size: int
-    minimum: float
-    median: float
-    maximum: float
-    mean: float
-
-
-def running_statistics(iterable, *, maxlen=None):
-    """Statistics for values seen so far or values in a sliding window.
-
-    Set *maxlen* to a positive integer to specify the maximum size
-    of the sliding window.  The default of *None* is equivalent to
-    an unbounded window.
-
-    Yields instances of a ``Stats`` dataclass with fields for the dataset *size*,
-    *minimum* value, *median* value, *maximum* value, and the arithmetic *mean*.
-
-    Supports numeric types such as int, float, Decimal, and Fraction,
-    but not complex numbers which are unorderable.
-    """
-
-    # fmt: off
-    t0, t1, t2, t3 = tee(iterable, 4)
-    return map(
-        Stats,
-        count(1) if maxlen is None else chain(range(1, maxlen), repeat(maxlen)),
-        running_min(t0, maxlen=maxlen),
-        running_median(t1, maxlen=maxlen),
-        running_max(t2, maxlen=maxlen),
-        running_mean(t3, maxlen=maxlen),
-    )
-    # fmt: on

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -16,7 +16,6 @@ from collections.abc import (
     Sized,
 )
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
 from decimal import Decimal
 from fractions import Fraction
 from threading import Lock
@@ -34,7 +33,6 @@ from typing_extensions import Protocol
 __all__ = [
     'AbortThread',
     'SequenceView',
-    'Stats',
     'adjacent',
     'all_unique',
     'always_iterable',
@@ -120,9 +118,6 @@ __all__ = [
     'rlocate',
     'rstrip',
     'run_length',
-    'running_min',
-    'running_max',
-    'running_statistics',
     'sample',
     'seekable',
     'serialize',
@@ -966,21 +961,3 @@ def concurrent_tee(
 def synchronized(
     func: Callable[..., Iterator[_T]],
 ) -> Callable[..., Iterator[_T]]: ...
-
-@dataclass(frozen=True, slots=True)
-class Stats:
-    size: int
-    minimum: float
-    median: float
-    maximum: float
-    mean: float
-
-def running_min(
-    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
-) -> Iterator[_NumberT]: ...
-def running_max(
-    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
-) -> Iterator[_NumberT]: ...
-def running_statistics(
-    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
-) -> Iterator[Stats]: ...

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -13,6 +13,7 @@ import random
 from bisect import bisect_left, insort
 from collections import deque
 from contextlib import suppress
+from dataclasses import dataclass
 from functools import lru_cache, reduce
 from heapq import heappush, heappushpop
 from itertools import (
@@ -34,11 +35,12 @@ from itertools import (
     zip_longest,
 )
 from math import prod, comb, isqrt, gcd
-from operator import mul, getitem, index, is_, itemgetter, truediv
+from operator import mul, getitem, index as _index, is_, itemgetter, truediv
 from random import randrange, sample, choice, shuffle
 from sys import hexversion
 
 __all__ = [
+    'Stats',
     'all_equal',
     'batched',
     'before_and_after',
@@ -76,8 +78,11 @@ __all__ = [
     'random_product',
     'repeatfunc',
     'roundrobin',
+    'running_max',
     'running_mean',
     'running_median',
+    'running_min',
+    'running_statistics',
     'sieve',
     'sliding_window',
     'subslices',
@@ -1402,7 +1407,7 @@ def running_median(iterable, *, maxlen=None):
     iterator = iter(iterable)
 
     if maxlen is not None:
-        maxlen = index(maxlen)
+        maxlen = _index(maxlen)
         if maxlen <= 0:
             raise ValueError('Window size should be positive')
         return _running_median_windowed(iterator, maxlen)
@@ -1455,6 +1460,124 @@ def running_mean(iterable, *, maxlen=None):
         raise ValueError('Window size should be positive')
 
     return _windowed_running_mean(iterator, maxlen)
+
+
+def _windowed_running_min(iterator, maxlen):
+    sis = deque()  # Strictly increasing subsequence
+    for index, value in enumerate(iterator):
+        if sis and sis[0][0] == index - maxlen:
+            sis.popleft()
+        while sis and not sis[-1][1] < value:  # Remove non-increasing values
+            sis.pop()
+        sis.append((index, value))  # Most recent value at position -1
+        yield sis[0][1]  # Window minimum at position 0
+
+
+def running_min(iterable, *, maxlen=None):
+    """Smallest of values seen so far or values in a sliding window.
+
+    Set *maxlen* to a positive integer to specify the maximum size
+    of the sliding window.  The default of *None* is equivalent to
+    an unbounded window.
+
+    For example:
+
+        >>> list(running_min([4, 3, 7, 0, 8, 1, 6, 2, 9, 5]))
+        [4, 3, 3, 0, 0, 0, 0, 0, 0, 0]
+
+        >>> list(running_min([4, 3, 7, 0, 8, 1, 6, 2, 9, 5], maxlen=3))
+        [4, 3, 3, 0, 0, 0, 1, 1, 2, 2]
+
+    Supports numeric types such as int, float, Decimal, and Fraction,
+    but not complex numbers which are unorderable.
+    """
+
+    iterator = iter(iterable)
+
+    if maxlen is None:
+        return accumulate(iterator, func=min)
+
+    if maxlen <= 0:
+        raise ValueError('Window size should be positive')
+
+    return _windowed_running_min(iterator, maxlen)
+
+
+def _windowed_running_max(iterator, maxlen):
+    sds = deque()  # Strictly decreasing subsequence
+    for index, value in enumerate(iterator):
+        if sds and sds[0][0] == index - maxlen:
+            sds.popleft()
+        while sds and not sds[-1][1] > value:  # Remove non-decreasing values
+            sds.pop()
+        sds.append((index, value))  # Most recent value at position -1
+        yield sds[0][1]  # Window maximum at position 0
+
+
+def running_max(iterable, *, maxlen=None):
+    """Largest of values seen so far or values in a sliding window.
+
+    Set *maxlen* to a positive integer to specify the maximum size
+    of the sliding window.  The default of *None* is equivalent to
+    an unbounded window.
+
+    For example:
+
+        >>> list(running_max([4, 3, 7, 0, 8, 1, 6, 2, 9, 5]))
+        [4, 4, 7, 7, 8, 8, 8, 8, 9, 9]
+
+        >>> list(running_max([4, 3, 7, 0, 8, 1, 6, 2, 9, 5], maxlen=3))
+        [4, 4, 7, 7, 8, 8, 8, 6, 9, 9]
+
+    Supports numeric types such as int, float, Decimal, and Fraction,
+    but not complex numbers which are unorderable.
+    """
+
+    iterator = iter(iterable)
+
+    if maxlen is None:
+        return accumulate(iterator, func=max)
+
+    if maxlen <= 0:
+        raise ValueError('Window size should be positive')
+
+    return _windowed_running_max(iterator, maxlen)
+
+
+@dataclass(frozen=True, slots=True)
+class Stats:
+    size: int
+    minimum: float
+    median: float
+    maximum: float
+    mean: float
+
+
+def running_statistics(iterable, *, maxlen=None):
+    """Statistics for values seen so far or values in a sliding window.
+
+    Set *maxlen* to a positive integer to specify the maximum size
+    of the sliding window.  The default of *None* is equivalent to
+    an unbounded window.
+
+    Yields instances of a ``Stats`` dataclass with fields for the dataset *size*,
+    *minimum* value, *median* value, *maximum* value, and the arithmetic *mean*.
+
+    Supports numeric types such as int, float, Decimal, and Fraction,
+    but not complex numbers which are unorderable.
+    """
+
+    # fmt: off
+    t0, t1, t2, t3 = tee(iterable, 4)
+    return map(
+        Stats,
+        count(1) if maxlen is None else chain(range(1, maxlen), repeat(maxlen)),
+        running_min(t0, maxlen=maxlen),
+        running_median(t1, maxlen=maxlen),
+        running_max(t2, maxlen=maxlen),
+        running_mean(t3, maxlen=maxlen),
+    )
+    # fmt: on
 
 
 def random_derangement(iterable):

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
 from decimal import Decimal
 from fractions import Fraction
 from typing import (
@@ -13,6 +14,7 @@ from typing import (
 )
 
 __all__ = [
+    'Stats',
     'all_equal',
     'batched',
     'before_and_after',
@@ -50,8 +52,11 @@ __all__ = [
     'random_product',
     'repeatfunc',
     'roundrobin',
+    'running_max',
     'running_mean',
     'running_median',
+    'running_min',
+    'running_statistics',
     'sieve',
     'sliding_window',
     'subslices',
@@ -202,10 +207,28 @@ def _strong_probable_prime(n: int, base: int) -> bool: ...
 def is_prime(n: int) -> bool: ...
 def loops(n: int) -> Iterator[None]: ...
 def multinomial(*counts: int) -> int: ...
+def random_derangement(iterable: Iterable[_T]) -> tuple[_T, ...]: ...
 def running_mean(
     iterable: Iterable[_NumberT], *, maxlen: int | None = ...
 ) -> Iterator[_NumberT]: ...
 def running_median(
     iterable: Iterable[_NumberT], *, maxlen: int | None = ...
 ) -> Iterator[_NumberT]: ...
-def random_derangement(iterable: Iterable[_T]) -> tuple[_T, ...]: ...
+def running_min(
+    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
+) -> Iterator[_NumberT]: ...
+def running_max(
+    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
+) -> Iterator[_NumberT]: ...
+
+@dataclass(frozen=True, slots=True)
+class Stats:
+    size: int
+    minimum: float
+    median: float
+    maximum: float
+    mean: float
+
+def running_statistics(
+    iterable: Iterable[_NumberT], *, maxlen: int | None = ...
+) -> Iterator[Stats]: ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.0.1
+current_version = 11.0.2
 commit = True
 tag = False
 files = more_itertools/__init__.py


### PR DESCRIPTION
This PR has the updates for bugfix release 11.0.2.
* #1143 was fixed by reverting #1107
* I missed the removal of `zip_equal` (ca002789a2c0fdb0c602fb0987216096553809df) when compiling the release notes for 11.0.0. Apologies for causing https://github.com/atopile/atopile/issues/1809.
* The typo fix in #1147 / #1149 is incorporated

We'll do a smaller release next time.