### PR TITLE
Fix empty ranges in numeric_range.__reversed__

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2402,10 +2402,14 @@ class numeric_range(Sequence):
         )
 
     def __reversed__(self):
+        # Empty iterator
+        try:
+            start = self._get_by_index(-1)
+        except IndexError:
+            return iter([])
+
         return iter(
-            numeric_range(
-                self._get_by_index(-1), self._start - self._step, -self._step
-            )
+            numeric_range(start, self._start - self._step, -self._step)
         )
 
     def count(self, value):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3137,6 +3137,9 @@ class NumericRangeTests(TestCase):
             self.assertTrue(dumps(r))  # assert not empty
             self.assertEqual(r, loads(dumps(r)))
 
+    def test_empty_reversed(self):
+        self.assertEqual(list(reversed(mi.numeric_range(0))), [])
+
 
 class CountCycleTests(TestCase):
     def test_basic(self):


### PR DESCRIPTION
This PR updates the handing of an empty ranges when using `numeric_range.__reversed__`.

Thanks to @rhettinger for the report.

Closes #1152