### PR TITLE
Faster counting in islice_extended()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2670,9 +2670,10 @@ def _islice_helper(it, s):
 
         if start < 0:
             # Consume all but the last -start items
-            wrapper = countable(it)
+            counter = count()
+            wrapper = map(lambda p, q: p, it, counter)
             cache = deque(wrapper, maxlen=-start)
-            len_iter = wrapper.items_seen
+            len_iter = next(counter)
 
             # Adjust start to be positive
             i = max(len_iter + start, 0)

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2670,12 +2670,10 @@ def _islice_helper(it, s):
 
         if start < 0:
             # Consume all but the last -start items
-
-            counter = count()
-            wrapper = map(itemgetter(0), zip(it, counter))
+            counter = count(1)
+            wrapper = compress(it, counter)
             cache = deque(wrapper, maxlen=-start)
-            del wrapper  # Clear reference held by zip()
-            len_iter = next(counter)
+            len_iter = next(counter) - 1
 
             # Adjust start to be positive
             i = max(len_iter + start, 0)
@@ -2729,11 +2727,10 @@ def _islice_helper(it, s):
         if (stop is not None) and (stop < 0):
             # Consume all but the last items
             n = -stop - 1
-            counter = count()
-            wrapper = map(itemgetter(0), zip(it, counter))
+            counter = count(1)
+            wrapper = compress(it, counter)
             cache = deque(wrapper, maxlen=n)
-            del wrapper  # Clear reference held by zip()
-            len_iter = next(counter)
+            len_iter = next(counter) - 1
 
             # If start and stop are both negative they are comparable and
             # we can just slice. Otherwise we can adjust start to be negative

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2670,9 +2670,11 @@ def _islice_helper(it, s):
 
         if start < 0:
             # Consume all but the last -start items
+
             counter = count()
-            wrapper = map(lambda p, q: p, it, counter)
+            wrapper = map(itemgetter(0), zip(it, counter))
             cache = deque(wrapper, maxlen=-start)
+            del wrapper  # Clear reference held by zip()
             len_iter = next(counter)
 
             # Adjust start to be positive
@@ -2728,8 +2730,9 @@ def _islice_helper(it, s):
             # Consume all but the last items
             n = -stop - 1
             counter = count()
-            wrapper = map(lambda p, q: p, it, counter)
+            wrapper = map(itemgetter(0), zip(it, counter))
             cache = deque(wrapper, maxlen=n)
+            del wrapper  # Clear reference held by zip()
             len_iter = next(counter)
 
             # If start and stop are both negative they are comparable and

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2727,9 +2727,10 @@ def _islice_helper(it, s):
         if (stop is not None) and (stop < 0):
             # Consume all but the last items
             n = -stop - 1
-            wrapper = countable(it)
+            counter = count()
+            wrapper = map(lambda p, q: p, it, counter)
             cache = deque(wrapper, maxlen=n)
-            len_iter = wrapper.items_seen
+            len_iter = next(counter)
 
             # If start and stop are both negative they are comparable and
             # we can just slice. Otherwise we can adjust start to be negative


### PR DESCRIPTION
As promised, here is a small edit with a faster way to count values.

Baseline:

```
% python3.15 -m timeit -s 'from more_itertools import consume, islice_extended as ise' 'consume(ise(iter(range(10**4)))[-100:])'
500 loops, best of 5: 655 usec per loop
```

Patched:
```
% python3.15 -m timeit -s 'from more_itertools import consume, islice_extended as ise' 'consume(ise(iter(range(10**4)))[-100:])'
500 loops, best of 5: 254 usec per loop
```