### PR TITLE
Simplify last()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -283,13 +283,10 @@ def last(iterable, default=_marker):
     raise ``ValueError``.
     """
     try:
-        if isinstance(iterable, Sequence):
-            return iterable[-1]
-        # Work around https://bugs.python.org/issue38525
         if getattr(iterable, '__reversed__', None):
             return next(reversed(iterable))
         return deque(iterable, maxlen=1)[-1]
-    except (IndexError, TypeError, StopIteration):
+    except (IndexError, StopIteration):
         if default is _marker:
             raise ValueError(
                 'last() was called on an empty iterable, '


### PR DESCRIPTION
Currently, `last()` has three paths: 1) negative indexing 2) reverse iteration and 3) forward iteration.   All cases covered by the first path could also be handled by the second path (because `Sequence` inherits from `Reversible`).

For sequence inputs, the speed effect is a wash (240 nsec vs 244 nsec).  The speedy `[-1]` lookup is offset by the slow `isinstance(iterable, Sequence)` test.

For iterator inputs, we get a nice speed improvement (from 356 nsec to 253 nsec).

Baseline:

```
% python3.15 -m timeit -s 'from more_itertools import last'  'last("abc")'
1000000 loops, best of 5: 240 nsec per loop
% python3.15 -m timeit -s 'from more_itertools import last'  'last(iter("abc"))'
1000000 loops, best of 5: 356 nsec per loop
```

Patched:

```
% python3.15 -m timeit -s 'from more_itertools import last'  'last("abc")'
1000000 loops, best of 5: 244 nsec per loop
% python3.15 -m timeit -s 'from more_itertools import last'  'last(iter("abc"))'
1000000 loops, best of 5: 253 nsec per loop
```