### PR TITLE
Fix typos in lstrip and consecutive_groups docstrings

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2559,8 +2559,8 @@ def lstrip(iterable, pred):
         >>> list(lstrip(iterable, pred))
         [1, 2, None, 3, False, None]
 
-    This function is analogous to to :func:`str.lstrip`, and is essentially
-    an wrapper for :func:`itertools.dropwhile`.
+    This function is analogous to :func:`str.lstrip`, and is essentially
+    a wrapper for :func:`itertools.dropwhile`.
 
     """
     return dropwhile(pred, iterable)
@@ -2813,8 +2813,8 @@ def consecutive_groups(iterable, ordering=None):
         ['i']
         ['l', 'm', 'n', 'o', 'p']
 
-    Each group of consecutive items is an iterator that shares it source with
-    *iterable*. When an an output group is advanced, the previous group is
+    Each group of consecutive items is an iterator that shares its source with
+    *iterable*. When an output group is advanced, the previous group is
     no longer available unless its elements are copied (e.g., into a ``list``).
 
         >>> iterable = [1, 2, 11, 12, 21, 22]


### PR DESCRIPTION
### Issue reference
<!-- Fixing trivial typos; no issue required per the PR template. -->
N/A — trivial typo fixes (the PR template notes an issue is not needed for typos).

### Changes
Fixes four small typos in two docstrings in `more_itertools/more.py`:

- **`lstrip`**: "analogous to to :func:`str.lstrip`" → "analogous to" (duplicate word), and "an wrapper for" → "a wrapper for" (article).
- **`consecutive_groups`**: "shares it source" → "shares its source", and "When an an output group" → "When an output group" (duplicate word).

Documentation only; no behavioural change.

### Checks and tests
- `ruff format --check` and `ruff check` pass.
- `python -m unittest tests.test_more` — all 695 tests pass.