### PR TITLE
`time_limited` stubs fixes

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -28,7 +28,7 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing_extensions import Protocol
+from typing_extensions import Protocol, Self
 
 __all__ = [
     'AbortThread',
@@ -658,12 +658,14 @@ def set_partitions(
     max_size: int | None = ...,
 ) -> Iterator[list[list[_T]]]: ...
 
-class time_limited(Generic[_T], Iterator[_T]):
+class time_limited(Generic[_T_co], Iterator[_T_co]):
+    limit_seconds: float
+    timed_out: bool
     def __init__(
-        self, limit_seconds: float, iterable: Iterable[_T]
+        self, limit_seconds: float, iterable: Iterable[_T_co]
     ) -> None: ...
-    def __iter__(self) -> islice_extended[_T]: ...
-    def __next__(self) -> _T: ...
+    def __iter__(self) -> Self: ...
+    def __next__(self) -> _T_co: ...
 
 @overload
 def only(


### PR DESCRIPTION
### Issue reference

No issue; is that ok?

### Changes

The `time_limited` stubs were missing attribute annotations for `limit_seconds` and `timed_out`, so I added them. 
Its `__iter__` method had an incorrect return type, so I fixed it by changing it to `Self`, because it returns `self` at runtime.
I also changed changed the polarity of its generic type parameter from invariant to covariant; it's only used in an output position (the return type of `__next__`), so covariance is more appropriate.

### Checks and tests
<!-- Please create and activate a virtual environment and then run `make all-checks` to ensure sure your branch meets the standards enforced by GitHub Actions. -->

All green :)