### PR TITLE
Add subfactorial()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,7 @@ Python iterables.
 |                        | `multinomial <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.multinomial>`_,                                                                       |
 |                        | `nth_prime <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.nth_prime>`_,                                                                           |
 |                        | `sieve <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.sieve>`_,                                                                                   |
+|                        | `subfactorial <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.subfactorial>`_,                                                                     |
 |                        | `totient <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.totient>`_                                                                                |
 +------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Statistics             | `running_min <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.running_min>`_,                                                                       |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -323,6 +323,7 @@ The tools focus on math with integers.
 ----
 
 .. autofunction:: nth_prime
+.. autofunction:: subfactorial
 
 ----
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -161,6 +161,7 @@ __all__ = [
     'stagger',
     'strip',
     'strictly_n',
+    'subfactorial',
     'substrings',
     'substrings_indexes',
     'synchronized',
@@ -936,7 +937,8 @@ def derangements(iterable, r=None):
 
     The number of derangements of a set of size *n* is known as the
     "subfactorial of n".  For n > 0, the subfactorial is:
-    ``round(math.factorial(n) / math.e)``.
+    ``round(math.factorial(n) / math.e)``.   The more-itertools function
+    :func:`subfactorial` computes this directly.
 
     References:
 
@@ -5507,3 +5509,29 @@ class _concurrent_tee:
                     link[1] = [None, None]
         value, self.link = link
         return value
+
+
+def subfactorial(n):
+    """Number of permutations of *n* elements with no fixed points.
+
+    The :func:`subfactorial` function computes the length of
+    :func:`derangements`.  For example, there are 1,854 ways to
+    rearrange the letters in word "epsilon" without leaving any
+    letter in its original position:
+
+        >>> from more_itertools import derangements, ilen
+        >>> ilen(derangements('epsilon'))
+        1854
+        >>> subfactorial(len('epsilon'))
+        1854
+
+    Reference:  https://oeis.org/A000166
+
+    """
+    if n < 0:
+        raise ValueError
+    sf = adj = 1
+    for i in range(n + 1):
+        sf = sf * i + adj
+        adj = -adj
+    return sf

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -135,6 +135,7 @@ __all__ = [
     'stagger',
     'strip',
     'strictly_n',
+    'subfactorial',
     'substrings',
     'substrings_indexes',
     'synchronized',
@@ -950,6 +951,7 @@ def extract(
     *,
     monotonic: bool = ...,
 ) -> Iterator[_T]: ...
+def subfactorial(n: int) -> int: ...
 
 class serialize(Generic[_T], Iterator[_T]):
     iterator: Iterator[_T]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6993,3 +6993,33 @@ class TestRunningStats(TestCase):
             list(mi.running_statistics(map(complex, data)))
         with self.assertRaises(TypeError):
             list(mi.running_statistics(map(complex, data), maxlen=3))
+
+
+class TestSubfactorial(TestCase):
+    def test_oeis_baseline(self):
+        # https://oeis.org/A000166
+        reference_cases = """
+        1, 0, 1, 2, 9, 44, 265, 1854, 14833, 133496, 1334961, 14684570,
+        176214841, 2290792932, 32071101049, 481066515734, 7697064251745,
+        130850092279664, 2355301661033953, 44750731559645106,
+        895014631192902121, 18795307255050944540, 413496759611120779881,
+        9510425471055777937262
+        """.replace(',', ' ').split()
+        for n, target_str in enumerate(reference_cases):
+            with self.subTest(n=n):
+                self.assertEqual(mi.subfactorial(n), int(target_str))
+
+    def test_vs_derangements(self):
+        for n in range(10):
+            with self.subTest(n=n):
+                self.assertEqual(
+                    mi.subfactorial(n), mi.ilen(mi.derangements('.' * n))
+                )
+
+    def test_error_cases(self):
+        with self.assertRaises(TypeError):
+            mi.subfactorial(5.0)  # float input
+        with self.assertRaises(TypeError):
+            mi.subfactorial('5')  # string input
+        with self.assertRaises(ValueError):
+            mi.subfactorial(-1)  # negative input


### PR DESCRIPTION
For combinatoric tools, it is nice to have a direct way to compute the expected length.

The `math` module provides `prod` for `product`, `comb` for `combinations`, and `perm` for `permutations`.  Likewise, the `more_itertools` project provides `multinomial` for `distinct_permutations`.

I propose adding `subfactorial` for `derangements`.