### PR TITLE
Fix broken test

### DIFF
--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6302,14 +6302,16 @@ class PowersetOfSetsTests(TestCase):
         hash_count = 0
 
         class Str(str):
-            def __hash__(true_self):
+            def __hash__(self):
                 nonlocal hash_count
                 hash_count += 1
-                return super.__hash__(true_self)
+                return super().__hash__()
 
+        # Seven input values should have 7 hash calls.
+        # Four distinct input values should have 2 ** 4 powersets.
         iterable = map(Str, 'ABBBCDD')
-        self.assertEqual(len(list(mi.powerset_of_sets(iterable))), 128)
-        self.assertLessEqual(hash_count, 14)
+        self.assertEqual(mi.ilen(mi.powerset_of_sets(iterable)), 16)
+        self.assertEqual(hash_count, 7)
 
     def test_baseset(self):
         iterable = [0, 1, 2]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6307,11 +6307,14 @@ class PowersetOfSetsTests(TestCase):
                 hash_count += 1
                 return super().__hash__()
 
-        # Seven input values should have 7 hash calls.
         # Four distinct input values should have 2 ** 4 subsets
         iterable = map(Str, 'ABBBCDD')
         self.assertEqual(mi.ilen(mi.powerset_of_sets(iterable)), 16)
-        self.assertEqual(hash_count, 7)
+
+        # Seven input values should have 7 hash calls.
+        # However, PyPy's version of dict.fromkeys calls hash a
+        # second time for set inputs. This doubles the 7 to 14.
+        self.assertIn(hash_count, {7, 14})
 
     def test_baseset(self):
         iterable = [0, 1, 2]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6307,14 +6307,14 @@ class PowersetOfSetsTests(TestCase):
                 hash_count += 1
                 return super().__hash__()
 
-        # Four distinct input values should have 2 ** 4 subsets
-        iterable = map(Str, 'ABBBCDD')
-        self.assertEqual(mi.ilen(mi.powerset_of_sets(iterable)), 16)
+        # Six distinct input values should have 2 ** 6 subsets.
+        iterable = map(Str, 'ABBBCDDEEEF')
+        self.assertEqual(mi.ilen(mi.powerset_of_sets(iterable)), 2**6)
 
-        # Seven input values should have 7 hash calls.
+        # Eleven input values should have 11 hash calls.
         # However, PyPy's version of dict.fromkeys calls hash a
-        # second time for set inputs. This doubles the 7 to 14.
-        self.assertIn(hash_count, {7, 14})
+        # second time for set inputs. This doubles the 11 to 22.
+        self.assertIn(hash_count, {11, 22})
 
     def test_baseset(self):
         iterable = [0, 1, 2]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6308,7 +6308,7 @@ class PowersetOfSetsTests(TestCase):
                 return super().__hash__()
 
         # Seven input values should have 7 hash calls.
-        # Four distinct input values should have 2 ** 4 powersets.
+        # Four distinct input values should have 2 ** 4 subsets
         iterable = map(Str, 'ABBBCDD')
         self.assertEqual(mi.ilen(mi.powerset_of_sets(iterable)), 16)
         self.assertEqual(hash_count, 7)


### PR DESCRIPTION
* The `Str` test class has a bug.   It's `super.__hash__` should be `super().__hash__`. 
* The expected number of sets produced should be `2**4` because there are 4 distinct elements in the input.
* The expected number of `hash()` calls should be 7 because there are 7 elements in the input.