### PR TITLE
Add primes generator

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -333,6 +333,7 @@ The tools focus on math with integers.
 .. autofunction:: is_prime
 .. autofunction:: multinomial
 .. autofunction:: sieve
+.. autofunction:: primes
 .. autofunction:: totient
 
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -69,6 +69,7 @@ __all__ = [
     'polynomial_derivative',
     'powerset',
     'prepend',
+    'primes',
     'quantify',
     'reshape',
     'random_combination_with_replacement',
@@ -923,6 +924,63 @@ def sieve(n):
         data[p * p : n : p + p] = bytes(len(range(p * p, n, p + p)))
         start = p * p
     yield from iter_index(data, 1, start)
+
+
+def primes():
+    """Yield the prime numbers, lazily and without an upper bound.
+
+    >>> from itertools import islice
+    >>> list(islice(primes(), 10))
+    [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+    Unlike :func:`sieve`, which requires a known limit and builds a table of
+    size proportional to that limit, this generator runs forever using a
+    *segmented* Sieve of Eratosthenes.  Primes are produced one block at a
+    time, so memory use stays proportional to the square root of the largest
+    prime yielded rather than the prime itself.  Pair it with the usual
+    iterator tools to take what you need::
+
+        >>> from itertools import takewhile
+        >>> list(takewhile(lambda p: p < 30, primes()))
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+    """
+    # 2 is the only even prime; emit it directly and sieve odds afterward.
+    yield 2
+
+    block_size = 1 << 15  # number of odd candidates per block
+    # Odd primes known so far, used to mark composites in each block.  Sieving
+    # the block [low, high) only needs the primes up to isqrt(high - 1).
+    base_primes = []
+    base_checked = 1  # base_primes holds every odd prime <= base_checked
+
+    low = 3
+    while True:
+        high = (
+            low + 2 * block_size
+        )  # block covers the odd numbers in [low, high)
+
+        # Extend base_primes until they cover the square root of this block.
+        limit = isqrt(high - 1)
+        if limit > base_checked:
+            base_primes = list(sieve(limit + 1))[1:]  # drop 2; keep odd primes
+            base_checked = limit
+
+        # data[i] tracks the odd number low + 2 * i; start it all-prime.
+        data = bytearray([1]) * block_size
+        for p in base_primes:
+            # First odd multiple of p that is both >= low and >= p * p.
+            start = max(p * p, low + (-low % p))
+            if start % 2 == 0:
+                start += p  # composites to mark must stay odd
+            data[(start - low) // 2 :: p] = bytes(
+                len(range(start, high, 2 * p))
+            )
+
+        for i in iter_index(data, 1):
+            yield low + 2 * i
+
+        low = high
 
 
 def _batched(iterable, n, *, strict=False):  # pragma: no cover

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -43,6 +43,7 @@ __all__ = [
     'polynomial_derivative',
     'powerset',
     'prepend',
+    'primes',
     'quantify',
     'reshape',
     'random_combination_with_replacement',
@@ -179,6 +180,7 @@ def iter_index(
     stop: int | None = ...,
 ) -> Iterator[int]: ...
 def sieve(n: int) -> Iterator[int]: ...
+def primes() -> Iterator[int]: ...
 def _batched(
     iterable: Iterable[_T], n: int, *, strict: bool = False
 ) -> Iterator[tuple[_T, ...]]: ...
@@ -220,7 +222,6 @@ def running_min(
 def running_max(
     iterable: Iterable[_NumberT], *, maxlen: int | None = ...
 ) -> Iterator[_NumberT]: ...
-
 @dataclass(frozen=True, slots=True)
 class Stats:
     size: int

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -9,6 +9,7 @@ from itertools import (
     groupby,
     permutations,
     islice,
+    takewhile,
 )
 from operator import mul, eq
 from math import comb, prod, factorial
@@ -1072,6 +1073,64 @@ class SieveTests(TestCase):
         for n in (0, 1, 2):
             with self.subTest(n=n):
                 self.assertEqual(list(mi.sieve(n)), [])
+
+
+class PrimesTests(TestCase):
+    def test_basic(self):
+        self.assertEqual(
+            mi.take(18, mi.primes()),
+            [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19,
+                23,
+                29,
+                31,
+                37,
+                41,
+                43,
+                47,
+                53,
+                59,
+                61,
+            ],
+        )
+
+    def test_matches_sieve(self):
+        # primes() and sieve() must agree across many internal blocks.
+        for n in (1, 2, 3, 4, 100, 1_000, 100_000, 500_000):
+            with self.subTest(n=n):
+                expected = list(mi.sieve(n))
+                actual = list(takewhile(lambda p: p < n, mi.primes()))
+                self.assertEqual(actual, expected)
+
+    def test_prime_counts(self):
+        for n, expected in (
+            (100, 25),
+            (1_000, 168),
+            (10_000, 1229),
+            (100_000, 9592),
+        ):
+            with self.subTest(n=n):
+                count = mi.ilen(takewhile(lambda p: p < n, mi.primes()))
+                self.assertEqual(count, expected)
+
+    def test_all_prime(self):
+        for p in mi.take(2000, mi.primes()):
+            with self.subTest(p=p):
+                self.assertTrue(mi.is_prime(p))
+
+    def test_lazy_and_infinite(self):
+        # An infinite generator: islice should return without exhausting it.
+        it = mi.primes()
+        self.assertEqual(mi.take(3, it), [2, 3, 5])
+        # The same iterator continues from where it left off.
+        self.assertEqual(mi.take(3, it), [7, 11, 13])
 
 
 class BatchedTests(TestCase):


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools #1168 

<!-- Replace XXXX with the issue number from your "propose-a-new-itertool" issue.
     A new itertool should be proposed in an issue and accepted before this PR. -->

### Changes

Adds `primes()` — an **unbounded, lazy prime number generator**.

Unlike the existing `sieve(n)`, which requires a known upper limit and builds a
table proportional to that limit, `primes()` runs forever using a *segmented*
Sieve of Eratosthenes. Primes are produced one block at a time, so memory use
stays proportional to the square root of the largest prime yielded rather than
the prime itself.

```python
>>> from itertools import islice, takewhile
>>> list(islice(primes(), 10))
[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
>>> list(takewhile(lambda p: p < 30, primes()))
[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
