### PR TITLE
Remove code unused in `count_cycle` after prior refactor

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2453,8 +2453,7 @@ def count_cycle(iterable, n=None):
     seq = tuple(iterable)
     if not seq:
         return iter(())
-    counter = count() if n is None else range(n)
-    return zip(repeat_each(counter, len(seq)), cycle(seq))
+    return zip(repeat_each(count(), len(seq)), cycle(seq))
 
 
 def mark_ends(iterable):


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#1170

### Changes
Eliminates an always unreachable branch in `count_cycle()`.
