### PR TITLE
Use `_typeshed` protocols in the stubs

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -24,11 +24,17 @@ from typing import (
     Callable,
     Generic,
     Literal,
+    TypeAlias,
     TypeVar,
     overload,
     type_check_only,
 )
 from typing_extensions import Protocol, Self
+from _typeshed import (
+    SupportsDunderLT,
+    SupportsGetItem,
+    Viewable as _SizedIterable,
+)
 
 __all__ = [
     'AbortThread',
@@ -174,15 +180,10 @@ if sys.version_info >= (3, 10):
 else:
     _ClassInfo = type | tuple[_ClassInfo, ...]
 
-@type_check_only
-class _SizedIterable(Protocol[_T_co], Sized, Iterable[_T_co]): ...
+_SupportsLessThan: TypeAlias = SupportsDunderLT[Any]
 
 @type_check_only
 class _SizedReversible(Protocol[_T_co], Sized, Reversible[_T_co]): ...
-
-@type_check_only
-class _SupportsSlicing(Protocol[_T_co]):
-    def __getitem__(self, __k: slice) -> _T_co: ...
 
 def chunked(
     iterable: Iterable[_T], n: int | None, strict: bool = ...
@@ -307,7 +308,7 @@ def side_effect(
     after: Callable[[], object] | None = ...,
 ) -> Iterator[_T]: ...
 def sliced(
-    seq: _SupportsSlicing[_T], n: int, strict: bool = ...
+    seq: SupportsGetItem[slice, _T], n: int, strict: bool = ...
 ) -> Iterator[_T]: ...
 def split_at(
     iterable: Iterable[_T],
@@ -861,9 +862,6 @@ def duplicates_justseen(
 def classify_unique(
     iterable: Iterable[_T], key: Callable[[_T], _U] | None = ...
 ) -> Iterator[tuple[_T, bool, bool]]: ...
-
-class _SupportsLessThan(Protocol):
-    def __lt__(self, __other: Any) -> bool: ...
 
 _SupportsLessThanT = TypeVar("_SupportsLessThanT", bound=_SupportsLessThan)
 


### PR DESCRIPTION
### Issue reference

No issue (refactor only)

### Changes

This replaces the custom helper protocols in the `more.pyi` stubs with existing protocols from the type-check-only `_typeshed` stdlib module. 

The leading `_` in `_typeshed` might seem fishy, but this module is used heavily by a lot of stub libraries, including the typeshed stubs themselves, and its API has been very stable for a long time now. So it's not something I'd worry about (and even in the worst case where `_typeshed` gets deleted or something, then some users will see some additional squiggly lines; that's all).

### Checks and tests

Everything is still green.