### PR TITLE
Remove needless `__future__.annotations` imports in the stubs

### DIFF
--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -1,7 +1,5 @@
 """Stubs for more_itertools.more"""
 
-from __future__ import annotations
-
 import types
 
 from collections.abc import (

--- a/more_itertools/recipes.pyi
+++ b/more_itertools/recipes.pyi
@@ -1,7 +1,5 @@
 """Stubs for more_itertools.recipes"""
 
-from __future__ import annotations
-
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from decimal import Decimal


### PR DESCRIPTION
### Issue reference
-

### Changes
Eh yea sorry for the PR spam, but I found another opportunity for improvements in the stubs :sweat_smile:. 

The story here is that `from __future__ import annotations` is purely a runtime thing, which roughly speaking basically stringifies every annotation, working around the lack of support for future (type) references in Python <3.15. In `.pyi` stubs, there's no need for this; it already supports forward references.

Ruff also has a rule for this: https://docs.astral.sh/ruff/rules/future-annotations-in-stub/

### Checks and tests
All green