### PR TITLE
Remove `threading` import and make `queue` import lazy

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,6 +1,7 @@
 import math
 import types
 
+from _thread import allocate_lock
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
 from contextlib import suppress
@@ -39,7 +40,6 @@ from operator import (
 )
 from sys import maxsize
 from time import monotonic
-from threading import Lock
 
 from .recipes import (
     _marker,
@@ -5397,7 +5397,7 @@ class serialize:
 
     def __init__(self, iterable):
         self._iterator = iter(iterable)
-        self._lock = Lock()
+        self._lock = allocate_lock()
 
     def __iter__(self):
         return self
@@ -5494,7 +5494,7 @@ class _concurrent_tee:
         else:
             self.iterator = iter(iterable)
             self.link = [None, None]
-            self.lock = Lock()
+            self.lock = allocate_lock()
 
     def __iter__(self):
         return self

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = frozenset({'queue'})
+
 import math
 import types
 


### PR DESCRIPTION
### Changes
Since the `_thread` module is documented to be available whenever `threading` is, and `threading` takes 10 ms to load whereas `_thread` takes <100 microseconds, I believe it desirable to replace all instances of `threading.Lock` with the functionally equivalent `_thread.allocate_lock()` and remove the `threading` import.
