### PR TITLE
Support negative start/stop in iter_index for general iterables

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -5,6 +5,12 @@ Version History
 .. automodule:: more_itertools
    :noindex:
 
+Unreleased
+----------
+
+* Changes to existing functions:
+    * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+
 11.1.0
 ------
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -889,6 +889,13 @@ def iter_index(iterable, value, start=0, stop=None):
 
     """
     seq_index = getattr(iterable, 'index', None)
+    if seq_index is None and (start < 0 or (stop is not None and stop < 0)):
+        # islice() rejects negative indices, but the fast path (below) accepts
+        # them with the usual from-the-end semantics. Materialize so that both
+        # paths agree for negative *start* / *stop*.
+        iterable = tuple(iterable)
+        seq_index = iterable.index
+
     if seq_index is None:
         # Slow path for general iterables
         iterator = islice(iterable, start, stop)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1026,6 +1026,23 @@ class IterIndexTests(TestCase):
         expected = [0, 1, 4]
         self.assertEqual(actual, expected)
 
+    def test_negative_start_and_stop(self):
+        # Negative *start* / *stop* should behave like the built-in
+        # ``str.index`` / ``list.index`` and produce identical results for the
+        # fast (sequence) and slow (general-iterable) code paths.
+        iterable = 'AABCADEAF'  # 'A' occurs at indexes 0, 1, 4, 7
+        cases = [
+            (dict(start=-3), [7]),
+            (dict(start=-9), [0, 1, 4, 7]),
+            (dict(stop=-2), [0, 1, 4]),
+            (dict(start=-5, stop=-1), [4, 7]),
+        ]
+        for kwargs, expected in cases:
+            for wrapper in (list, iter):
+                with self.subTest(kwargs=kwargs, wrapper=wrapper):
+                    actual = list(mi.iter_index(wrapper(iterable), 'A', **kwargs))
+                    self.assertEqual(actual, expected)
+
 
 class SieveTests(TestCase):
     def test_basic(self):


### PR DESCRIPTION
### Problem

`iter_index` accepts negative `start` / `stop` for sequences (the fast `.index`
path) but crashes for general iterables (the slow `islice` path):

```python
from more_itertools import iter_index

list(iter_index('AABCADEAF', 'A', -3))        # [7]
list(iter_index(iter('AABCADEAF'), 'A', -3))  # ValueError: Indices for islice() must be None or an integer...
```

### Cause

`iter_index` has two code paths:

- **Fast path** (objects with `.index`, e.g. `str`/`list`): negatives work via
  `str.index` / `list.index`, with the usual from-the-end semantics.
- **Slow path** (general iterables): `islice(iterable, start, stop)` rejects
  negative indices, so any negative `start`/`stop` raises.

### Why it's a bug (oracle)

`IterIndexTests` runs every case `for wrapper in (list, iter)` and asserts the
two paths produce identical output — i.e. the maintained invariant is that the
sequence and general-iterable paths agree. Negative bounds break that invariant:
the `list` wrapper yields a result, the `iter` wrapper raises.

### Fix

When `start` or `stop` is negative on the slow path, materialize the iterable to
a tuple and use its `.index`, so both paths share the same from-the-end
semantics. Materialization only happens on the (rare) negative-index path; the
common non-negative slow path stays fully lazy and is untouched.

```python
seq_index = getattr(iterable, 'index', None)
if seq_index is None and (start < 0 or (stop is not None and stop < 0)):
    iterable = tuple(iterable)
    seq_index = iterable.index
```

### Tests

Added `IterIndexTests.test_negative_start_and_stop`, covering negative `start`,
negative `stop`, and combined negative bounds, each checked for both the `list`
and `iter` wrappers (matching the existing test style). Verified red before the
fix (the four cases raise) and green after; full suite `891 passed`. A
differential grid (sequences x values x `start`/`stop` in `-15..15`) shows zero
remaining fast-vs-slow disagreements.

---

*Disclosure: I prepared this patch with the help of an AI assistant, under my
direction. I found the inconsistency via fast-vs-slow differential testing,
confirmed the oracle against the existing tests, and verified the fix
red-to-green myself.*
