### PR TITLE
Optimize `minmax` to avoid creating an intermediate tuple of positional arguments

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4830,8 +4830,10 @@ def minmax(*iterable, key=None, default=_marker):
     `recipe <https://code.activestate.com/recipes/577916-fast-minmax-function>`__ by
     Raymond Hettinger.
     """
-    if not iterable: raise TypeError('`minmax()` expected one or more positional arguments.')
-    if len(iterable) == 1: iterable = iterable[0]
+    if not iterable:
+        raise TypeError('`minmax()` expected one or more positional arguments.')
+    if len(iterable) == 1:
+        iterable = iterable[0]
 
     it = iter(iterable)
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4831,7 +4831,9 @@ def minmax(*iterable, key=None, default=_marker):
     Raymond Hettinger.
     """
     if not iterable:
-        raise TypeError('`minmax()` expected one or more positional arguments.')
+        raise TypeError(
+            '`minmax()` expected one or more positional arguments.'
+        )
     if len(iterable) == 1:
         iterable = iterable[0]
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4795,7 +4795,7 @@ def classify_unique(iterable, key=None):
         yield element, is_unique_justseen, is_unique_everseen
 
 
-def minmax(iterable_or_value, *others, key=None, default=_marker):
+def minmax(*iterable, key=None, default=_marker):
     """Returns both the smallest and largest items from an iterable
     or from two or more arguments.
 
@@ -4830,7 +4830,8 @@ def minmax(iterable_or_value, *others, key=None, default=_marker):
     `recipe <https://code.activestate.com/recipes/577916-fast-minmax-function>`__ by
     Raymond Hettinger.
     """
-    iterable = (iterable_or_value, *others) if others else iterable_or_value
+    if not iterable: raise TypeError('`minmax()` expected one or more positional arguments.')
+    if len(iterable) == 1: iterable = iterable[0]
 
     it = iter(iterable)
 

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -891,35 +891,35 @@ _SupportsLessThanT = TypeVar("_SupportsLessThanT", bound=_SupportsLessThan)
 
 @overload
 def minmax(
-    iterable_or_value: Iterable[_SupportsLessThanT], *, key: None = None
+    __iterable: Iterable[_SupportsLessThanT], *, key: None = None
 ) -> tuple[_SupportsLessThanT, _SupportsLessThanT]: ...
 @overload
 def minmax(
-    iterable_or_value: Iterable[_T], *, key: Callable[[_T], _SupportsLessThan]
+    __iterable: Iterable[_T], *, key: Callable[[_T], _SupportsLessThan]
 ) -> tuple[_T, _T]: ...
 @overload
 def minmax(
-    iterable_or_value: Iterable[_SupportsLessThanT],
+    __iterable: Iterable[_SupportsLessThanT],
     *,
     key: None = None,
     default: _U,
 ) -> _U | tuple[_SupportsLessThanT, _SupportsLessThanT]: ...
 @overload
 def minmax(
-    iterable_or_value: Iterable[_T],
+    __iterable: Iterable[_T],
     *,
     key: Callable[[_T], _SupportsLessThan],
     default: _U,
 ) -> _U | tuple[_T, _T]: ...
 @overload
 def minmax(
-    iterable_or_value: _SupportsLessThanT,
+    __value: _SupportsLessThanT,
     __other: _SupportsLessThanT,
     *others: _SupportsLessThanT,
 ) -> tuple[_SupportsLessThanT, _SupportsLessThanT]: ...
 @overload
 def minmax(
-    iterable_or_value: _T,
+    __value: _T,
     __other: _T,
     *others: _T,
     key: Callable[[_T], _SupportsLessThan],


### PR DESCRIPTION
### Changes

If a lot of positional arguments are passed to `minmax`, all but the first are collected into a tuple, which then has the first prepended to it. This incurs the extra cost of a tuple creation and concatenation. This can be avoided by changing the signature.
