### PR TITLE
Fix locate tail window matches

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2534,11 +2534,19 @@ def locate(iterable, pred=bool, window_size=None):
     if window_size < 1:
         raise ValueError('window size must be at least 1')
 
-    it = windowed(iterable, window_size, fillvalue=_marker)
-    return compress(
-        count(),
-        (pred(*(x for x in w if x is not _marker)) for w in it),
-    )
+    def _windows():
+        last_window = None
+        for window in windowed(iterable, window_size, fillvalue=_marker):
+            last_window = window
+            yield tuple(x for x in window if x is not _marker)
+
+        if last_window is not None and all(
+            x is not _marker for x in last_window
+        ):
+            for i in range(1, window_size):
+                yield last_window[i:]
+
+    return compress(count(), (pred(*window) for window in _windows()))
 
 
 def longest_common_prefix(iterables):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -3227,6 +3227,13 @@ class LocateTests(TestCase):
         expected = [0, 3]
         self.assertEqual(actual, expected)
 
+    def test_window_size_tail(self):
+        iterable = [0, 1, 2, 3]
+        pred = lambda *args: args in [(2, 3), (3,)]
+        actual = list(mi.locate(iterable, pred, window_size=3))
+        expected = [2, 3]
+        self.assertEqual(actual, expected)
+
     def test_window_size_large(self):
         iterable = [1, 2, 3, 4]
         pred = lambda *args: True
@@ -3940,6 +3947,14 @@ class RlocateTests(TestCase):
         for it in (iterable, iter(iterable)):
             actual = list(mi.rlocate(it, pred, window_size=2))
             expected = [3, 0]
+            self.assertEqual(actual, expected)
+
+    def test_window_size_tail(self):
+        iterable = [0, 1, 2, 3]
+        pred = lambda *args: args in [(2, 3), (3,)]
+        for it in (iterable, iter(iterable)):
+            actual = list(mi.rlocate(it, pred, window_size=3))
+            expected = [3, 2]
             self.assertEqual(actual, expected)
 
     def test_window_size_large(self):


### PR DESCRIPTION
## Summary
- emit trailing partial windows in `locate(..., window_size=...)` after the final full window
- preserve the existing single-check behavior when the iterable is shorter than the window
- add `locate` and `rlocate` coverage for tail-window matches

## Tests
- `/Users/vinzzy/.local/bin/python3.14 -m unittest tests.test_more.LocateTests tests.test_more.RlocateTests`
- `/Users/vinzzy/.local/bin/python3.14 -m unittest -v`
- `/Users/vinzzy/.local/bin/uvx ruff check .`
- `/Users/vinzzy/.local/bin/uvx ruff format --check .`
- `/Users/vinzzy/.local/bin/python3.14 -m compileall -q more_itertools tests`
- `git diff --check`