### PR TITLE
Fix replace empty window output

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,6 +10,7 @@ Unreleased
 
 * Changes to existing functions:
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+    * :func:`replace` was fixed to return no items for empty iterables with a window size greater than one (thanks to gaoflow)
 
 11.1.0
 ------

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3418,7 +3418,7 @@ def replace(iterable, pred, substitutes, count=None, window_size=1):
     # Add padding such that the number of windows matches the length of the
     # iterable
     it = chain(iterable, repeat(_marker, window_size - 1))
-    windows = windowed(it, window_size)
+    windows = windowed(it, window_size, fillvalue=_marker)
 
     n = 0
     for w in windows:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4009,6 +4009,14 @@ class ReplaceTests(TestCase):
         expected = [5, 6, 7]
         self.assertEqual(actual, expected)
 
+    def test_window_size_empty(self):
+        iterable = []
+        pred = lambda *args: True
+        substitutes = [5, 6, 7]
+        actual = list(mi.replace(iterable, pred, substitutes, window_size=3))
+        expected = []
+        self.assertEqual(actual, expected)
+
     def test_window_size_zero(self):
         iterable = range(10)
         pred = lambda *args: True


### PR DESCRIPTION
## Summary
- prevent `replace(..., window_size>1)` from yielding a padding `None` for empty iterables
- use the existing `_marker` sentinel as the `windowed()` fill value so padding is filtered consistently
- add regression coverage for the empty-window case

## Tests
- `python -m unittest tests.test_more.ReplaceTests`
- `python -m unittest -v`
- `uvx ruff check more_itertools/more.py tests/test_more.py`
- `uvx ruff format --check more_itertools/more.py tests/test_more.py`
- `python -m compileall -q more_itertools tests`
- `git diff --check`
