### PR TITLE
Improve difference typing for initial

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,6 +10,7 @@ Unreleased
 
 * Changes to existing functions:
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+    * The type hints for :func:`difference` were improved for calls with *initial* set.
 
 11.1.0
 ------

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -598,13 +598,19 @@ def consecutive_groups(
 @overload
 def difference(
     iterable: Iterable[_T],
+    *,
+    initial: _T,
+) -> Iterator[_T]: ...
+@overload
+def difference(
+    iterable: Iterable[_T],
     func: Callable[[_T, _T], _U] = ...,
     *,
     initial: None = ...,
 ) -> Iterator[_T | _U]: ...
 @overload
 def difference(
-    iterable: Iterable[_T], func: Callable[[_T, _T], _U] = ..., *, initial: _U
+    iterable: Iterable[_T], func: Callable[[_T, _T], _U], *, initial: _T
 ) -> Iterator[_U]: ...
 
 class SequenceView(Generic[_T_co], Sequence[_T_co]):


### PR DESCRIPTION
Refs #1179

## Summary
- add an overload for `difference(..., initial=...)` when the default function is used
- type explicit-function `initial` values as the accumulated input item type instead of the callback result type
- document the typing improvement in the unreleased notes

## Tests
- `uv run --no-project --with mypy python -m mypy -c 'from more_itertools import difference\nfrom typing import Iterator, assert_type\nassert_type(difference([10, 11, 13], initial=True), Iterator[int])'`\n- `uv run --no-project --with mypy mypy --strict more_itertools/more.pyi`\n- `PYTHONPATH=. uv run --no-project --with mypy stubtest more_itertools.more more_itertools.recipes`\n- `uv run --no-project python -m unittest -v`\n- `uv run --no-project --with ruff ruff check more_itertools tests`\n- `uv run --no-project --with ruff ruff format --check .`\n- `git diff --check`\n\nAI assistance was used under my direction.