### PR TITLE
Upgrade GitHub actions, test Python 3.14 release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14.0-rc.2", "pypy-3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -30,7 +30,7 @@ jobs:
       run: make package
     - name: Upload packages
       if: "matrix.python-version == '3.10'"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: more-itertools-packages
         path: dist/*


### PR DESCRIPTION
This PR upgrades the GitHub actions (checkout, setup-python, and upload-artifact) and the Python version testing matrix (3.14 instead of RC2).