### PR TITLE
Handle empty interleave_evenly input

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1338,6 +1338,9 @@ def interleave_evenly(iterables, lengths=None):
 
     dims = len(lengths)
 
+    if not dims:
+        return
+
     # sort iterables by length, descending
     lengths_permute = sorted(
         range(dims), key=lambda i: lengths[i], reverse=True

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1173,6 +1173,10 @@ class InterleaveEvenlyTests(TestCase):
         actual = list(mi.interleave_evenly([a, b]))
         self.assertEqual(actual, expected)
 
+    def test_no_iterables(self):
+        self.assertEqual(list(mi.interleave_evenly([])), [])
+        self.assertEqual(list(mi.interleave_evenly([], lengths=[])), [])
+
     def test_three_iters(self):
         a = ["a1", "a2", "a3", "a4", "a5"]
         b = ["b1", "b2", "b3"]


### PR DESCRIPTION
### Issue reference
Closes more-itertools/more-itertools#1192

### Changes
- Return immediately when `interleave_evenly` receives no iterables.
- Add regression coverage for both inferred lengths and explicit `lengths=[]`.

The failure happened because the empty-input path left `dims == 0` and then indexed `lengths_desc[0]` while selecting the primary iterable.

### Checks and tests
`make all-checks` was not available in this Windows shell because `make` is not installed, so I ran the equivalent targets manually:

- Red test on clean `origin/master`: `python -m unittest tests.test_more.InterleaveEvenlyTests.test_no_iterables` failed with `IndexError: list index out of range`
- Green test: `python -m unittest tests.test_more.InterleaveEvenlyTests.test_no_iterables`
- `python -m unittest`
- `.venv\Scripts\python.exe -m coverage run --include=more_itertools/*.py -m unittest`
- `.venv\Scripts\python.exe -m coverage report --show-missing --fail-under=99`
- `.venv\Scripts\python.exe -m ruff format --check .`
- `.venv\Scripts\python.exe -m ruff check more_itertools tests`
- `.venv\Scripts\python.exe -m mypy.stubtest more_itertools.more more_itertools.recipes`
- `.venv\Scripts\sphinx-build.exe -W -b html docs docs\_build\html`
- `.venv\Scripts\python.exe -m flit build --setup-py`
- `.venv\Scripts\python.exe -m twine check dist\*`