### PR TITLE
Raise for negative tail sizes on sized iterables

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -152,6 +152,9 @@ def tail(n, iterable):
     ['E', 'F', 'G']
 
     """
+    if n < 0:
+        raise ValueError('n must be at least 0')
+
     try:
         size = len(iterable)
     except TypeError:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -84,6 +84,10 @@ class TailTests(TestCase):
         """Length of iterator is less than requested tail"""
         self.assertEqual(list(mi.tail(8, iter('ABCDEFG'))), list('ABCDEFG'))
 
+    def test_iterator_negative(self):
+        """Negative tail sizes should raise for non-sized iterables."""
+        self.assertRaises(ValueError, lambda: list(mi.tail(-1, iter('ABCDEFG'))))
+
     def test_sized_greater(self):
         """Length of sized iterable is greater than requested tail"""
         self.assertEqual(list(mi.tail(3, 'ABCDEFG')), list('EFG'))

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -96,6 +96,10 @@ class TailTests(TestCase):
         """Length of sized iterable is less than requested tail"""
         self.assertEqual(list(mi.tail(8, 'ABCDEFG')), list('ABCDEFG'))
 
+    def test_sized_negative(self):
+        """Negative tail sizes should raise for sized iterables."""
+        self.assertRaises(ValueError, lambda: list(mi.tail(-1, 'ABCDEFG')))
+
 
 class ConsumeTests(TestCase):
     """Tests for ``consume()``"""


### PR DESCRIPTION
## What changed

`tail()` now rejects negative `n` values before choosing the sized or iterator implementation path.

## Why

The iterator path already raises `ValueError` for negative sizes via `deque(..., maxlen=n)`, but the sized-iterable path returned an empty iterator instead. That made `tail(-1, iter(seq))` and `tail(-1, seq)` behave differently for the same invalid argument.

## Validation

- `python -m pytest tests\test_recipes.py::TailTests -q`
- `python -m pytest tests\test_recipes.py -q`
- `python -m ruff check more_itertools\recipes.py tests\test_recipes.py`
- `git diff --check`