### PR TITLE
Use `.. deprecated::` directive for `callback_iter` and `pairwise`

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4017,10 +4017,8 @@ class AbortThread(BaseException):
 class callback_iter:
     """Convert a function that uses callbacks to an iterator.
 
-    .. warning::
-
-       This function is deprecated as of version 11.0.0. It will be removed in a future
-       major release.
+    .. deprecated:: 11.0.0
+       Will be removed in a future major release.
 
     Let *func* be a function that takes a `callback` keyword argument.
     For example:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -342,10 +342,8 @@ def pairwise(iterable):
     """
     Wrapper for :func:`itertools.pairwise`.
 
-    .. warning::
-
-       This function is deprecated as of version 11.0.0. It will be removed in a future
-       major release.
+    .. deprecated:: 11.0.0
+       Will be removed in a future major release.
     """
     return itertools_pairwise(iterable)
 


### PR DESCRIPTION
### Issue reference
more-itertools/more-itertools#1198
