### PR TITLE
Raise for negative slice sizes in sliced()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1534,6 +1534,9 @@ def sliced(seq, n, strict=False):
     For non-sliceable iterables, see :func:`chunked`.
 
     """
+    if n < 0:
+        raise ValueError('n must be at least 0')
+
     iterator = takewhile(len, (seq[i : i + n] for i in count(0, n)))
     if strict:
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1407,6 +1407,15 @@ class SlicedTests(TestCase):
         with self.assertRaises(ValueError):
             list(mi.sliced(seq, 4, strict=True))
 
+    def test_negative(self):
+        """Negative slice sizes should raise instead of silently
+        yielding a wrong result."""
+        seq = 'ABCDEFG'
+        self.assertRaises(ValueError, lambda: list(mi.sliced(seq, -1)))
+        self.assertRaises(
+            ValueError, lambda: list(mi.sliced(seq, -1, strict=True))
+        )
+
     def test_numpy_like_array(self):
         # Numpy arrays don't behave like Python lists - calling bool()
         # on them doesn't return False for empty lists and True for non-empty


### PR DESCRIPTION
## Summary

`sliced(seq, n)` with a **negative** `n` silently returns a wrong result instead of raising or returning an empty iterator. This is the worst failure mode — no error, just quietly incorrect output:

```pycon
>>> from more_itertools import sliced
>>> list(sliced('ABCDEFG', -1))
['ABCDEF']          # expected: an error (or at worst [])
>>> list(sliced([1, 2, 3, 4, 5], -2))
[[1, 2, 3]]
```

## Root cause

`sliced` builds its slices with:

```python
iterator = takewhile(len, (seq[i : i + n] for i in count(0, n)))
```

With a negative `n`, `count(0, n)` starts at `0` and steps *downward*. The first generated slice is `seq[0 : 0 + n]` — e.g. for `n == -1`, `seq[0:-1]`, which is a non-empty prefix. The next index is negative, so `seq[i : i + n]` becomes empty and `takewhile(len, ...)` stops. The result is a single truncated slice that looks plausible but is meaningless.

With `strict=True` the negative case raised a **misleading** error — `ValueError("seq is not divisible by n.")` — which points at the wrong cause.

## Fix

Guard `n < 0` up front and raise a clear domain error, matching the behavior of `sliced`'s documented sibling and of `tail`:

```python
if n < 0:
    raise ValueError('n must be at least 0')
```

- `chunked()` (the non-sliceable counterpart, referenced in `sliced`'s own docstring) already rejects a negative `n`.
- `tail()` was **recently** changed the same way — commit `d64a7d6` *"Raise for negative tail sizes on sized iterables"* — using the identical message `'n must be at least 0'`. This PR follows that precedent. (Note `sliced` was actually *worse* than pre-fix `tail`, which returned an empty result rather than wrong data.)

The message and shape are copied from the merged `tail` fix for consistency.

## Behavior before / after

| call | before | after |
|------|--------|-------|
| `list(sliced('ABCDEFG', -1))` | `['ABCDEF']` (wrong) | `ValueError: n must be at least 0` |
| `list(sliced([1,2,3,4,5], -2))` | `[[1, 2, 3]]` (wrong) | `ValueError: n must be at least 0` |
| `list(sliced('ABCDEFG', -1, strict=True))` | `ValueError: seq is not divisible by n.` (misleading) | `ValueError: n must be at least 0` |
| `list(sliced('ABCDEFGHI', 3))` | `['ABC','DEF','GHI']` | `['ABC','DEF','GHI']` (unchanged) |
| `list(sliced('ABCDEFGHI', 4))` | `['ABCD','EFGH','I']` | `['ABCD','EFGH','I']` (unchanged) |
| `list(sliced([1,2,3], 0))` | `[]` | `[]` (unchanged) |

`n == 0` and all `n >= 1` cases are untouched.

## Tests

Added `SlicedTests.test_negative` (default and `strict=True` paths). Proven to guard the bug by stashing the source change:

- **without** the fix: `test_negative` **FAILS** — `AssertionError: ValueError not raised by <lambda>` (confirming the silent wrong output).
- **with** the fix: `test_negative` **PASSES**.

Full suite: `730 passed, 19938 subtests passed` (was 729 + the new test), no regressions. `ruff check` and `ruff format --check` clean on both changed files; `sliced` doctests pass.
