### PR TITLE
Use .. deprecated:: directive for pairwise and callback_iter

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4017,10 +4017,8 @@ class AbortThread(BaseException):
 class callback_iter:
     """Convert a function that uses callbacks to an iterator.
 
-    .. warning::
-
-       This function is deprecated as of version 11.0.0. It will be removed in a future
-       major release.
+    .. deprecated:: 11.0.0
+       This function is deprecated. It will be removed in a future major release.
 
     Let *func* be a function that takes a `callback` keyword argument.
     For example:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4018,7 +4018,7 @@ class callback_iter:
     """Convert a function that uses callbacks to an iterator.
 
     .. deprecated:: 11.0.0
-       This function is deprecated. It will be removed in a future major release.
+       This class is deprecated. It will be removed in a future major release.
 
     Let *func* be a function that takes a `callback` keyword argument.
     For example:

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -342,10 +342,9 @@ def pairwise(iterable):
     """
     Wrapper for :func:`itertools.pairwise`.
 
-    .. warning::
-
-       This function is deprecated as of version 11.0.0. It will be removed in a future
-       major release.
+    .. deprecated:: 11.0.0
+       This function is deprecated. It will be removed in a future major release.
+       Use :func:`itertools.pairwise` directly.
     """
     return itertools_pairwise(iterable)
 


### PR DESCRIPTION
## Summary

`pairwise` and `callback_iter` were deprecated in version 11.0.0, but their docstrings use a generic `.. warning::` admonition instead of Sphinx's `.. deprecated::` directive.

This PR swaps both to use the semantically correct directive:

```rst
# Before
.. warning::

   This function is deprecated as of version 11.0.0. ...

# After
.. deprecated:: 11.0.0
   This function is deprecated. It will be removed in a future major release.
```

## Why

`.. deprecated::` is Sphinx's standard directive for marking deprecations (same family as `.. versionadded::` and `.. versionchanged::`). It produces consistent "Deprecated since version 11.0.0" styling and is what tooling and readers expect when scanning for deprecations. A generic `.. warning::` box just looks like any other caution note.

## Changes

- `more_itertools/recipes.py` — `pairwise`: `.. warning::` → `.. deprecated:: 11.0.0`, added "Use `itertools.pairwise` directly."
- `more_itertools/more.py` — `callback_iter`: `.. warning::` → `.. deprecated:: 11.0.0`

No code changes — docstrings only.

Fixes #1198.