### PR TITLE
Raise ValueError for invalid group length in grouper

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,6 +10,7 @@ Unreleased
 
 * Changes to existing functions:
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+    * :func:`grouper` now raises ``ValueError`` for a group length below one, matching :func:`batched`, instead of silently returning an empty iterator (thanks to vidigoat)
 
 11.1.0
 ------

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -377,6 +377,8 @@ def grouper(iterable, n, incomplete='fill', fillvalue=None):
     ValueError
 
     """
+    if n < 1:
+        raise ValueError('n must be at least one')
     iterators = [iter(iterable)] * n
     match incomplete:
         case 'fill':

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -361,6 +361,14 @@ class GrouperTests(TestCase):
         with self.assertRaises(ValueError):
             list(mi.grouper('ABCD', 3, incomplete='bogus'))
 
+    def test_invalid_n(self):
+        # A group length below one is nonsensical and previously
+        # returned an empty iterator instead of signalling the error.
+        for n in [0, -1, -3]:
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    list(mi.grouper('ABCDEF', n))
+
 
 class RoundrobinTests(TestCase):
     """Tests for ``roundrobin()``"""


### PR DESCRIPTION
### Changes

`grouper` silently returns an empty iterator when given a group length below one:

```pycon
>>> list(grouper('ABCDEF', -1))
[]
>>> list(grouper('ABCDEF', 0))
[]
```

This happens because `[iter(iterable)] * n` is an empty list for any `n < 1`, and `zip`/`zip_longest` over no iterators yields nothing. The invalid argument is swallowed rather than reported.

Its sibling recipe `batched` already raises `ValueError` for `n < 1`:

```pycon
>>> list(batched('ABCDEF', -1))
ValueError: n must be at least one
```

This PR makes `grouper` do the same, so an unusable group length is signalled instead of quietly producing wrong output. The valid path is unchanged. Added a regression test and a changelog entry.

### Checks and tests

`make check` (ruff format/check, stubtest) and the full `unittest` suite pass locally; coverage on `recipes.py` remains at 100%.
