### PR TITLE
Add threading to __lazy_modules__ and restore the import of it, reverting c6b640

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1,9 +1,8 @@
-__lazy_modules__ = frozenset({'queue'})
+__lazy_modules__ = frozenset({'queue', 'threading'})
 
 import math
 import types
 
-from _thread import allocate_lock
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
 from contextlib import suppress
@@ -42,6 +41,7 @@ from operator import (
 )
 from sys import maxsize
 from time import monotonic
+from threading import Lock
 
 from .recipes import (
     _marker,
@@ -5403,7 +5403,7 @@ class serialize:
 
     def __init__(self, iterable):
         self._iterator = iter(iterable)
-        self._lock = allocate_lock()
+        self._lock = Lock()
 
     def __iter__(self):
         return self
@@ -5500,7 +5500,7 @@ class _concurrent_tee:
         else:
             self.iterator = iter(iterable)
             self.link = [None, None]
-            self.lock = allocate_lock()
+            self.lock = Lock()
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Completes #1208, reverts [commit](https://github.com/more-itertools/more-itertools/pull/1178/changes/c6b640cadeb46bc9a3882b792b9709ca13ee8816) to replace threading with _thread, and adds threading to __lazy_modules__ (alongside queue)