### PR TITLE
Fix stability in running_min and running_max

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -1482,7 +1482,7 @@ def _windowed_running_min(iterator, maxlen):
             s.popleft()
 
         # Remove decreasing values
-        while s and not s[-1][1] <= value:
+        while s and value < s[-1][1]:
             s.pop()
 
         # Place newest value at the end
@@ -1534,7 +1534,7 @@ def _windowed_running_max(iterator, maxlen):
             s.popleft()
 
         # Remove increasing values
-        while s and not s[-1][1] >= value:
+        while s and value > s[-1][1]:
             s.pop()
 
         # Place newest value at the end

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -1481,7 +1481,7 @@ def _windowed_running_min(iterator, maxlen):
         if s and s[0][0] == index - maxlen:
             s.popleft()
 
-        # Remove decreasing values
+        # Remove entries where the new value is smaller
         while s and value < s[-1][1]:
             s.pop()
 
@@ -1533,7 +1533,7 @@ def _windowed_running_max(iterator, maxlen):
         if s and s[0][0] == index - maxlen:
             s.popleft()
 
-        # Remove increasing values
+        # Remove entries where the new value is bigger
         while s and value > s[-1][1]:
             s.pop()
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -1477,18 +1477,11 @@ def _windowed_running_min(iterator, maxlen):
     s = deque()
 
     for index, value in enumerate(iterator):
-        # Has the current minimum aged out?
         if s and s[0][0] == index - maxlen:
             s.popleft()
-
-        # Remove entries where the new value is smaller
         while s and value < s[-1][1]:
             s.pop()
-
-        # Place newest value at the end
         s.append((index, value))
-
-        # Current minimum is at position zero
         yield s[0][1]
 
 
@@ -1529,18 +1522,11 @@ def _windowed_running_max(iterator, maxlen):
     s = deque()
 
     for index, value in enumerate(iterator):
-        # Has the current maximum aged out?
         if s and s[0][0] == index - maxlen:
             s.popleft()
-
-        # Remove entries where the new value is bigger
         while s and value > s[-1][1]:
             s.pop()
-
-        # Place newest value at the end
         s.append((index, value))
-
-        # Current maximum is at position zero
         yield s[0][1]
 
 

--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -1471,14 +1471,25 @@ def running_mean(iterable, *, maxlen=None):
 
 
 def _windowed_running_min(iterator, maxlen):
-    sis = deque()  # Strictly increasing subsequence
+    # Monotonically increasing subsequence of potential minimums,
+    # ordered by arrival time, with the window minimum at s[0]
+    # and the newest value at s[-1].
+    s = deque()
+
     for index, value in enumerate(iterator):
-        if sis and sis[0][0] == index - maxlen:
-            sis.popleft()
-        while sis and not sis[-1][1] < value:  # Remove non-increasing values
-            sis.pop()
-        sis.append((index, value))  # Most recent value at position -1
-        yield sis[0][1]  # Window minimum at position 0
+        # Has the current minimum aged out?
+        if s and s[0][0] == index - maxlen:
+            s.popleft()
+
+        # Remove decreasing values
+        while s and not s[-1][1] <= value:
+            s.pop()
+
+        # Place newest value at the end
+        s.append((index, value))
+
+        # Current minimum is at position zero
+        yield s[0][1]
 
 
 def running_min(iterable, *, maxlen=None):
@@ -1512,14 +1523,25 @@ def running_min(iterable, *, maxlen=None):
 
 
 def _windowed_running_max(iterator, maxlen):
-    sds = deque()  # Strictly decreasing subsequence
+    # Monotonically decreasing subsequence of potential maximums,
+    # ordered by arrival time, with the window maximum at s[0]
+    # and the newest value at s[-1].
+    s = deque()
+
     for index, value in enumerate(iterator):
-        if sds and sds[0][0] == index - maxlen:
-            sds.popleft()
-        while sds and not sds[-1][1] > value:  # Remove non-decreasing values
-            sds.pop()
-        sds.append((index, value))  # Most recent value at position -1
-        yield sds[0][1]  # Window maximum at position 0
+        # Has the current maximum aged out?
+        if s and s[0][0] == index - maxlen:
+            s.popleft()
+
+        # Remove increasing values
+        while s and not s[-1][1] >= value:
+            s.pop()
+
+        # Place newest value at the end
+        s.append((index, value))
+
+        # Current maximum is at position zero
+        yield s[0][1]
 
 
 def running_max(iterable, *, maxlen=None):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6823,6 +6823,14 @@ class TestRunningMin(TestCase):
             list(mi.running_min(iter(data))),
         )
 
+    def test_stability(self):
+        # min(x, y) returns x when x == y
+        data = [0, 0.0, Fraction(0)]
+        self.assertEqual(
+            list(map(type, mi.running_min(data, maxlen=2))),
+            [type(min(data[0:1])), type(min(data[0:2])), type(min(data[1:3]))],
+        )
+
 
 class TestRunningMax(TestCase):
     def test_basic(self):
@@ -6867,6 +6875,14 @@ class TestRunningMax(TestCase):
         self.assertEqual(
             list(mi.running_max(iter(data), maxlen=len(data) * 2)),
             list(mi.running_max(iter(data))),
+        )
+
+    def test_stability(self):
+        # max(x, y) returns x when x == y
+        data = [0, 0.0, Fraction(0)]
+        self.assertEqual(
+            list(map(type, mi.running_max(data, maxlen=2))),
+            [type(max(data[0:1])), type(max(data[0:2])), type(max(data[1:3]))],
         )
 
 


### PR DESCRIPTION
The builtin functions `min(x, y)` and `max(x, y)` are both stable and return `x` when `x == y`.

Fix this by replacing `not x < y` with `y < x` and `not x > y` with `y > x` to allow equal values in the subsequence, letting the oldest equal value win.

Also, take this opportunity to improve readability with a better comment about the sequence invariant .