### PR TITLE
Ignore step when comparing one-value numeric_ranges

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2343,6 +2343,9 @@ class numeric_range(Sequence):
             empty_other = not bool(other)
             if empty_self or empty_other:
                 return empty_self and empty_other  # True if both empty
+            elif len(self) == 1 or len(other) == 1:
+                # Step doesn't shape a one-value range, so range() ignores it
+                return self._start == other._start and len(self) == len(other)
             else:
                 return (
                     self._start == other._start
@@ -2369,10 +2372,13 @@ class numeric_range(Sequence):
             )
 
     def __hash__(self):
-        if self:
-            return hash((self._start, self._get_by_index(-1), self._step))
-        else:
+        if not self:
             return self._EMPTY_HASH
+        elif len(self) == 1:
+            # __eq__ ignores step here, so it must not reach the hash either
+            return hash((self._start, self._start, None))
+        else:
+            return hash((self._start, self._get_by_index(-1), self._step))
 
     def __iter__(self):
         values = (self._start + (n * self._step) for n in count())

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2911,12 +2911,32 @@ class NumericRangeTests(TestCase):
                 mi.numeric_range(*expected_args), mi.numeric_range(*args)[sl]
             )
 
+    def test_eq_single_element_ignores_step(self):
+        # Mirrors range(): a range holding one value is equal to any other
+        # range holding that value, whatever the step. The empty case is
+        # already special-cased above.
+        self.assertEqual(range(2, 3, 1), range(2, 3, 5))
+        self.assertEqual(
+            mi.numeric_range(2, 3, 1), mi.numeric_range(2, 3, 5)
+        )
+        self.assertEqual(
+            hash(mi.numeric_range(2, 3, 1)), hash(mi.numeric_range(2, 3, 5))
+        )
+        self.assertEqual(
+            mi.numeric_range(
+                Fraction(1, 2), Fraction(3, 4), Fraction(1, 3)
+            ),
+            mi.numeric_range(
+                Fraction(1, 2), Fraction(3, 4), Fraction(5, 1)
+            ),
+        )
     def test_hash(self):
         for args, expected in [
             ((1.0, 6.0, 1.5), hash((1.0, 5.5, 1.5))),
             ((1.0, 7.0, 1.5), hash((1.0, 5.5, 1.5))),
             ((1.0, 7.5, 1.5), hash((1.0, 7.0, 1.5))),
-            ((1.0, 1.5, 1.5), hash((1.0, 1.0, 1.5))),
+            # A one-value range hashes without its step, matching __eq__
+            ((1.0, 1.5, 1.5), hash((1.0, 1.0, None))),
             ((1.5, 1.0, 1.5), hash(range(0, 0))),
             ((1.5, 1.5, 1.5), hash(range(0, 0))),
             (


### PR DESCRIPTION
### Issue reference
Closes #1214

## Problem

`numeric_range` is documented as "an extension of the built-in `range()` function", but it disagrees with `range()` about one-value ranges:

```python
>>> range(2, 3, 1) == range(2, 3, 5)                      # both hold [2]
True
>>> numeric_range(2, 3, 1) == numeric_range(2, 3, 5)      # both hold [2]
False
```

A step doesn't shape a range that holds a single value, so `range()` ignores it — the same reason `__eq__` here **already** special-cases the empty case:

```python
empty_self = not bool(self)
empty_other = not bool(other)
if empty_self or empty_other:
    return empty_self and empty_other  # True if both empty
```

`numeric_range(2, 2, 1) == numeric_range(5, 5, 9)` is `True` today, matching `range`. One value is the same boundary, one step short.

This is exact for the types where it matters (ints, `Fraction`, `Decimal`) — it isn't a float-tolerance question.

## Fix

Skip the step comparison when either side holds one value:

```python
elif len(self) == 1 or len(other) == 1:
    return self._start == other._start and len(self) == len(other)
```

## The `__hash__` change, and the test I had to touch

`__hash__` has to follow `__eq__` or equal objects hash differently, so the one-value branch drops the step there too.

That means **I changed an existing pinned expectation** in `test_hash`, which is worth calling out rather than burying:

```python
-            ((1.0, 1.5, 1.5), hash((1.0, 1.0, 1.5))),
+            # A one-value range hashes without its step, matching __eq__
+            ((1.0, 1.5, 1.5), hash((1.0, 1.0, None))),
```

`numeric_range(1.0, 1.5, 1.5)` holds `[1.0]`. That entry pins the `hash((start, last, step))` formula rather than one-value semantics specifically — it's the only one-value entry in that list (I checked each: the others hold 0, 3, 4, 4, 5 and 6 values), and it moves as a consequence of the `__eq__` change, not to make anything pass. If you'd rather keep the hash formula as-is, then `__eq__` should stay as-is too and this whole PR should be dropped — they can't diverge.

## Testing

Added `test_eq_single_element_ignores_step`, which asserts the `range()` behaviour first so the expectation is anchored to CPython rather than to me, then the `numeric_range` equivalents plus a `Fraction` case and the hash.

The existing `test_eq` never covered this: every not-equal pair in it differs in actual contents, so a one-value pair holding the same value was never constructed.

Verified red first, then green. Full suite: 735 passed, 19950 subtests.

## Precedent

#363 ("Make `numeric_range` an iterable") made exactly this argument — `range` behaves one way, `numeric_range` behaves another, and the docstring says it's meant to be an extension of `range` — and it's the PR that added the empty-case handling this builds on.

---

This change was AI-assisted (Claude). I reproduced the mismatch against a real interpreter, checked it against `range()` directly rather than assuming, read #363 for the precedent, and ran the suites above myself. My first draft of the test was wrong — I'd picked `Fraction` ranges that hold two values each, not one — which the failure caught; the case in the PR holds one value on both sides, verified.