### PR TITLE
fix: return [] for weighted sample with empty reservoir

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -3851,6 +3851,9 @@ def _sample_weighted(iterator, k, weights, strict):
     reservoir = take(k, zip(weight_keys, iterator))
     if strict and len(reservoir) < k:
         raise ValueError('Sample larger than population')
+    if not reservoir:
+        # No elements (empty weights or empty iterable); match unweighted.
+        return []
 
     heapify(reservoir)
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -4525,6 +4525,13 @@ class SampleTests(TestCase):
         with self.assertRaises(ValueError):
             mi.sample(data, 6, strict=True)
 
+    def test_weighted_empty_weights_returns_empty(self):
+        """Empty weights yield an empty reservoir; return [] not IndexError."""
+        self.assertEqual(mi.sample([1, 2, 3], k=2, weights=[]), [])
+        self.assertEqual(mi.sample([], k=2, weights=[]), [])
+        with self.assertRaises(ValueError):
+            mi.sample([1, 2, 3], k=2, weights=[], strict=True)
+
     def test_counts(self):
         # Test with counts
         seed(0)


### PR DESCRIPTION
more_itertools.sample/_sample_weighted hits IndexError when empty weights exhausted before k. This PR fixes the regression with a focused test covering the case.
