### PR TITLE
Raise a clear ValueError for negative n in chunked()

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -230,6 +230,9 @@ def chunked(iterable, n, strict=False):
     list is yielded.
 
     """
+    if n is not None and n < 0:
+        raise ValueError('n must be at least 0')
+
     iterator = iter(partial(take, n, iter(iterable)), [])
     if strict:
         if n is None:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -70,6 +70,15 @@ class ChunkedTests(TestCase):
             list(mi.chunked('ABCDE', None)), [['A', 'B', 'C', 'D', 'E']]
         )
 
+    def test_negative(self):
+        """Test that a negative ``n`` raises a clear ``ValueError``, matching
+        the behavior of :func:`sliced`."""
+        self.assertRaisesRegex(
+            ValueError,
+            "n must be at least 0",
+            lambda: list(mi.chunked('ABCDE', -1)),
+        )
+
     def test_strict_false(self):
         """Test when ``n`` does not divide evenly into the length of the
         iterable and strict is false.


### PR DESCRIPTION
### Issue reference
No issue — this is a small bug fix, in the same spirit as the recently merged negative-size guards for `sliced` (#1200) and `tail` (#1194).

### Changes
`chunked()` was the only sizing helper without an `n < 0` guard. A negative `n` leaked `islice`'s internal message:

```
>>> list(chunked([1, 2, 3], -1))
ValueError: Stop argument for islice() must be None or an integer: 0 <= x <= sys.maxsize
```

This validates `n` up front and raises `ValueError('n must be at least 0')`, matching `sliced()` and `tail()`. `n=None` (single chunk) and `n=0` (empty result) are deliberately preserved and unchanged.

### Checks and tests
Added `ChunkedTests.test_negative`, mirroring `IchunkedTests.test_negative`. `ruff format --check`, `ruff check more_itertools tests`, and the full `tests/test_more.py` suite all pass locally.
