### PR TITLE
Fix convolve empty input handling

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -744,9 +744,18 @@ def convolve(signal, kernel):
     # this one was kept because the inlined window logic is faster
     # and it avoids an unnecessary deque-to-tuple conversion.
     kernel = tuple(kernel)[::-1]
+    if not kernel:
+        return
+
+    signal = iter(signal)
+    try:
+        first = next(signal)
+    except StopIteration:
+        return
+
     n = len(kernel)
     window = deque([0], maxlen=n) * n
-    for x in chain(signal, repeat(0, n - 1)):
+    for x in chain((first,), signal, repeat(0, n - 1)):
         window.append(x)
         yield _sumprod(kernel, window)
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -837,6 +837,14 @@ class Convolvetests(TestCase):
         expected = [0, 1, 1, 1, 1]
         self.assertEqual(actual, expected)
 
+    def test_empty_signal(self):
+        actual = list(mi.convolve([], [1, -1, 2]))
+        self.assertEqual(actual, [])
+
+    def test_empty_kernel(self):
+        actual = list(mi.convolve([1, 2, 3], []))
+        self.assertEqual(actual, [])
+
 
 class BeforeAndAfterTests(TestCase):
     def test_empty(self):


### PR DESCRIPTION
### Issue reference
Fixes more-itertools/more-itertools#1227

### Changes
`convolve()` preloads a zero-filled window and then flushes trailing zero padding after the signal. When the signal is empty, that flush path emitted synthetic zero results; when the kernel was empty, the zero-width window caused one zero result per signal item.

This change returns immediately for an empty kernel and probes the signal once before starting the padded convolution loop, so empty inputs produce an empty convolution while non-empty and infinite signals keep the existing lazy behavior.

Compatibility notes: no signature or type-stub changes; only empty-input edge cases change from padded zero outputs to no outputs.

### Reproduction
Before this fix on `master`:

```py
import more_itertools as mi

list(mi.convolve([], [1, -1, 2]))  # [0, 0]
list(mi.convolve([1, 2, 3], []))  # [0, 0, 0]
```

After this fix both calls return `[]`.

### Checks and tests
- `python -m unittest tests.test_recipes.Convolvetests -v`: Ran 5 tests, OK.
- Regression check with the library fix reverted: `test_empty_signal` and `test_empty_kernel` both fail (`[0, 0] != []` and `[0, 0, 0] != []`).
- `python -m unittest`: Ran 900 tests, OK (skipped=5).
- `ruff format --check .`: 13 files already formatted.
- `stubtest more_itertools.more more_itertools.recipes`: Success, no issues found in 2 modules.
- `ruff check more_itertools tests`: reports 139 existing lint findings with the installed `ruff 0.16.1` (no code-style changes were made for this bug fix).