### PR TITLE
 Update the convolve docstring 

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -718,7 +718,7 @@ def convolve(signal, kernel):
         >>> list(convolve([1, -1, -20], [1, -3]))
         [1, -4, -17, 60]
 
-    Examples of popular kinds of kernels:
+    Examples of useful kernels:
 
     * The kernel ``[0.25, 0.25, 0.25, 0.25]`` computes a moving average.
       For image data, this blurs the image and reduces noise.
@@ -727,11 +727,12 @@ def convolve(signal, kernel):
     * The kernel ``[1, -2, 1]`` estimates the second derivative of a
       function evaluated at evenly spaced inputs.
 
-    Convolutions are mathematically commutative; however, the inputs are
-    evaluated differently.  The signal is consumed lazily and can be
-    infinite. The kernel is fully consumed before the calculations begin.
+    Convolutions are mathematically commutative. However, the input iterables are
+    evaluated differently by this function. *signal* is consumed lazily and can be
+    infinite. *kernel* is fully consumed before calculations begin.
 
     Supports all numeric types: int, float, complex, Decimal, Fraction.
+    Note that empty input iterables will produce meaningless output.
 
     References:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ target-version = "py310"
 quote-style = "preserve"
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 ignore = ["E731", "E741"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
This PR updates the `convolve` docstring to note that empty input iterables produce meaningless output.

Also, this PR sets the `ruff` ruleset to match the default prior to version 0.16.0.

Resolves #1227
Resolves #1230