### PR TITLE
Close the last coverage gaps, fix a no-op equality assertion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format:
 coverage:
 	python -m pip install --upgrade -r requirements/testing.txt
 	coverage run --include="more_itertools/*.py" -m unittest
-	coverage report --show-missing --fail-under=99
+	coverage report --show-missing --fail-under=100
 
 .PHONY: test
 test:

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -32,7 +32,7 @@ from pickle import loads, dumps
 from random import Random, choices, random, randrange, seed
 from statistics import mean, median
 from string import ascii_letters
-from threading import Thread, Lock
+from threading import Event, Thread, Lock
 from time import sleep
 from typing import NamedTuple
 from unittest import TestCase, mock
@@ -704,6 +704,20 @@ class MinMaxTests(TestCase):
         self.assertTupleEqual(
             mi.minmax((x for x in [10, 3, 25]), key=str), (10, 3)
         )
+
+    def test_key_matches_builtins(self):
+        # The keyed code path compares items pairwise, so a single example
+        # only reaches some of its branches. Exhausting the short orderings
+        # covers each one. `x % 7` keeps every key distinct, so there are no
+        # ties and `min`/`max` pick the same items `minmax` does.
+        key = lambda x: x % 7
+        for n in range(1, 5):
+            for values in permutations(range(1, 8), n):
+                with self.subTest(values=values):
+                    self.assertTupleEqual(
+                        mi.minmax(values, key=key),
+                        (min(values, key=key), max(values, key=key)),
+                    )
 
     def test_default(self):
         with self.assertRaises(ValueError):
@@ -2760,7 +2774,10 @@ class NumericRangeTests(TestCase):
     def test_eq(self):
         # numeric_range objects are equal to themselves
         range_1 = mi.numeric_range(2, 4, 1)
-        self.assertTrue(range_1, range_1)
+        self.assertEqual(range_1, range_1)
+
+        # ...and to distinct objects covering the same values
+        self.assertEqual(range_1, mi.numeric_range(2, 4, 1))
 
         # numeric_range objects are not equal other types of objects
         self.assertNotEqual(mi.numeric_range(7.0), 1)
@@ -4779,6 +4796,24 @@ class CallbackIterTests(TestCase):
         with mi.callback_iter(func) as it:
             with self.assertRaises(RuntimeError):
                 it.result
+
+    def test_no_result_while_running(self):
+        # Unlike test_no_result, here the function has started but hasn't
+        # returned, so there is a pending future to interrogate.
+        gate = Event()
+
+        def func(callback=None):
+            callback(1, 'a', intermediate_total=1)
+            gate.wait()
+            return 6
+
+        with mi.callback_iter(func, wait_seconds=0.01) as it:
+            self.assertEqual(next(it), ((1, 'a'), {'intermediate_total': 1}))
+            self.assertFalse(it.done)
+            with self.assertRaises(RuntimeError):
+                it.result
+
+            gate.set()
 
     def test_exception(self):
         func = lambda callback=None: self._target(cb=callback, exc=ValueError)

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1468,6 +1468,31 @@ class PrimeFunctionTests(TestCase):
         with self.assertRaises(ValueError):
             mi.nth_prime(-1)
 
+    def test_nth_prime_tightened_bound(self):
+        # nth_prime() counts from 0 and asks for bounds on n + 1, so 688_382
+        # is the first argument that gets the tightened upper bound and
+        # 688_381 is the last that doesn't. The exact path sieves up to that
+        # bound, so tightening it too far would leave the sieve short and
+        # nth() would return None. At the threshold the bound clears the
+        # prime it has to reach by 3.
+        self.assertEqual(mi.nth_prime(688_381), 10_384_259)
+        self.assertEqual(mi.nth_prime(688_382), 10_384_261)
+
+    def test_nth_prime_approximate(self):
+        # approximate=True is ignored at or below 1,000,000
+        self.assertEqual(
+            mi.nth_prime(1_000_000, approximate=True),
+            mi.nth_prime(1_000_000),
+        )
+
+        # Above it, the result is some nearby prime rather than the exact one
+        for n in (1_000_001, 2_000_000):
+            with self.subTest(n=n):
+                approximate = mi.nth_prime(n, approximate=True)
+                exact = mi.nth_prime(n)
+                self.assertTrue(mi.is_prime(approximate))
+                self.assertLess(abs(approximate - exact) / exact, 0.01)
+
     def test_special_primes(self):
         for n in (
             # Mersenee primes:


### PR DESCRIPTION
### Issue reference

No issue - this is tests only, apart from a one-line change to the coverage
gate in the Makefile.

### Changes

Coverage was sitting at 99% with six uncovered lines. Chasing them turned up a
test that wasn't testing anything. `NumericRangeTests.test_eq` had:

```python
# numeric_range objects are equal to themselves
range_1 = mi.numeric_range(2, 4, 1)
self.assertTrue(range_1, range_1)
```

The second argument to `assertTrue` is the failure message, so that line only
checked that the range was truthy - it never called `__eq__` at all, which is
why the identity shortcut in `numeric_range.__eq__` showed as uncovered. If you
make `__eq__` return `False` unconditionally, the old assertion still passes.
Switched it to `assertEqual` and added a second case comparing distinct objects
over the same values.

The other gaps:

`minmax`'s keyed branch compares items pairwise and one of its four arms was
never reached. Rather than adding a single hand-picked case I cross-checked
against `min`/`max` with a key over the short permutations of a fixed set, which
reaches all four. The key is `x % 7` over `1..7` so every key is distinct and
there are no ties to make the comparison ambiguous.

`callback_iter.result` had no test for the window where the function has started
but hasn't returned - `test_no_result` only reaches the case where there's no
future yet, so the `TimeoutError` branch was dead. The new test gates the worker
on an `Event` rather than a sleep, so it isn't a timing race.

`nth_prime` tightens its upper bound from the 688,383rd prime onwards, and the
exact path sieves up to that bound, so tightening it too far would leave the
sieve short and `nth()` would return `None` instead of a prime. Nothing
exercised it. One thing worth flagging: at the threshold the bound clears the
prime it has to reach by 3, so there isn't much room there. I checked every n in
the window where the tightened bound feeds the exact path (688,382 through
1,000,000) and it holds throughout, but it's tighter than I expected. The
`approximate=True` path above 1,000,000 was also completely untested.

That gets it to 100%, so the Makefile gate goes to `--fail-under=100`. Happy to
drop that line if you'd rather keep the gate at 99 and leave headroom.

### Checks and tests

`make all-checks` passes on the branch: 902 tests OK, coverage 100% at
`--fail-under=100`, `ruff format --check` and `ruff check` clean, `stubtest`
clean on both modules.

Since this PR is almost entirely tests, I also checked each new test actually
fails for the right reason rather than just passing - broke each behaviour under
test in turn and confirmed the corresponding test caught it, then reverted. The
`minmax` cross-check fails 511 subtests when that branch is disabled, and the
`nth_prime` bound test fails if the bound is tightened by a further 4.
