### PR TITLE
Upgrade to flit 4.0.2+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,5 @@ docs:
 .PHONY: package
 package:
 	python -m pip install --upgrade -r requirements/packaging.txt
-	flit build --setup-py
+	flit build
 	twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.12,<4"]
+requires = ["flit_core >=4,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]

--- a/requirements/packaging.txt
+++ b/requirements/packaging.txt
@@ -1,5 +1,5 @@
-flit<4.0.0
-flit_core<4.0.0
+flit>=4.0.2,<5
+flit_core>=4.0.2,<5
 setuptools
 twine
 wheel


### PR DESCRIPTION
This PR upgrades the build system requirement for this package to be `flit>=4.0.2,<5`. It also removes the `--setup-py` call that prevented upgrading til now.

Closes #1233