### PR TITLE
Add limit_runs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Python iterables.
 |                        | `tail <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.tail>`_,                                                                                     |
 |                        | `unique_everseen <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.unique_everseen>`_,                                                               |
 |                        | `unique_justseen <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.unique_justseen>`_,                                                               |
+|                        | `limit_runs <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.limit_runs>`_,                                                                         |
 |                        | `unique <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.unique>`_,                                                                                 |
 |                        | `duplicates_everseen <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.duplicates_everseen>`_,                                                       |
 |                        | `duplicates_justseen <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.duplicates_justseen>`_,                                                       |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -224,6 +224,7 @@ These tools yield certain items from an iterable.
 .. autofunction:: tail
 .. autofunction:: unique_everseen
 .. autofunction:: unique_justseen
+.. autofunction:: limit_runs
 .. autofunction:: unique
 
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -114,6 +114,7 @@ __all__ = [
     'iterate',
     'join_mappings',
     'last',
+    'limit_runs',
     'locate',
     'longest_common_prefix',
     'lstrip',
@@ -5562,3 +5563,43 @@ def subfactorial(n):
         sf = sf * i + adj
         adj = -adj
     return sf
+
+
+def limit_runs(iterable, max_run, key=None):
+    """Yield items from *iterable*, capping each maximal run of
+    adjacent-equal items at *max_run* elements and dropping the rest.
+
+    >>> list(limit_runs('AAAABBBCCDAABBB', 2))
+    ['A', 'A', 'B', 'B', 'C', 'C', 'D', 'A', 'A', 'B', 'B']
+
+    Runs no longer than *max_run* pass through unchanged; note how the
+    second run of ``'A'`` above starts fresh after the ``'D'``.
+
+    Adjacency is measured the same way as :func:`unique_justseen`: only
+    neighbouring elements are compared, using ``key(item)`` when *key* is
+    given and the item itself otherwise.
+
+    >>> list(limit_runs('AAAaaaBBB', 2, str.lower))
+    ['A', 'A', 'B', 'B']
+
+    Capping each run at one element is equivalent to
+    :func:`unique_justseen`:
+
+    >>> from more_itertools import unique_justseen
+    >>> list(limit_runs('AAAABBBCCDAABBB', 1))
+    ['A', 'B', 'C', 'D', 'A', 'B']
+    >>> list(limit_runs('AAAABBBCCDAABBB', 1)) == list(
+    ...     unique_justseen('AAAABBBCCDAABBB')
+    ... )
+    True
+
+    """
+    if (
+        not isinstance(max_run, int)
+        or isinstance(max_run, bool)
+        or max_run < 1
+    ):
+        raise ValueError('max_run must be a positive integer')
+
+    for _, group in groupby(iterable, key):
+        yield from islice(group, max_run)

--- a/more_itertools/more.pyi
+++ b/more_itertools/more.pyi
@@ -87,6 +87,7 @@ __all__ = [
     'iterate',
     'join_mappings',
     'last',
+    'limit_runs',
     'locate',
     'longest_common_prefix',
     'lstrip',
@@ -1018,3 +1019,6 @@ def concurrent_tee(
 def synchronized(
     func: Callable[..., Iterator[_T]],
 ) -> Callable[..., Iterator[_T]]: ...
+def limit_runs(
+    iterable: Iterable[_T], max_run: int, key: Callable[[_T], _U] | None = ...
+) -> Iterator[_T]: ...

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -7076,3 +7076,80 @@ class TestSubfactorial(TestCase):
             mi.subfactorial('5')  # string input
         with self.assertRaises(ValueError):
             mi.subfactorial(-1)  # negative input
+
+
+class LimitRunsTests(TestCase):
+    def test_run_capping(self):
+        self.assertEqual(
+            list(mi.limit_runs('AAAABBBCCDAABBB', 2)),
+            list('AABBCCDAABB'),
+        )
+
+    def test_short_runs_pass_through(self):
+        # Runs of length <= max_run are unchanged.
+        self.assertEqual(
+            list(mi.limit_runs('ABBCCC', 3)),
+            list('ABBCCC'),
+        )
+
+    def test_empty_iterable(self):
+        self.assertEqual(list(mi.limit_runs('', 2)), [])
+        self.assertEqual(list(mi.limit_runs([], 5)), [])
+
+    def test_adjacency_without_key(self):
+        # A value recurring after a different item starts a fresh run.
+        self.assertEqual(
+            list(mi.limit_runs('AAABAAAA', 2)),
+            list('AABAA'),
+        )
+
+    def test_adjacency_with_key(self):
+        self.assertEqual(
+            list(mi.limit_runs('AAAaaaBBB', 2, str.lower)),
+            list('AABB'),
+        )
+
+    def test_adjacency_with_key_recurring_value(self):
+        # 'A' recurs after 'b' (case-insensitively different), so it
+        # starts a fresh run rather than joining the earlier one.
+        self.assertEqual(
+            list(mi.limit_runs('AaAbBaA', 1, str.lower)),
+            list('Aba'),
+        )
+
+    def test_vs_unique_justseen(self):
+        input = 'AAAABBBCCDAABBB'
+        self.assertEqual(
+            list(mi.limit_runs(input, 1)),
+            list(mi.unique_justseen(input)),
+        )
+
+    def test_vs_unique_justseen_key(self):
+        input = 'AaAABbBCCcDdAaBB'
+        self.assertEqual(
+            list(mi.limit_runs(input, 1, str.lower)),
+            list(mi.unique_justseen(input, str.lower)),
+        )
+
+    def test_laziness(self):
+        # Works against an infinite iterator without consuming it fully.
+        it = mi.limit_runs(count(), 3)
+        self.assertEqual(list(islice(it, 5)), [0, 1, 2, 3, 4])
+
+    def test_laziness_within_run(self):
+        # A single (infinite) run is capped, and items can be drawn
+        # lazily up to the cap without exhausting the source.
+        it = mi.limit_runs(repeat(1), 4)
+        self.assertEqual(list(islice(it, 4)), [1, 1, 1, 1])
+
+    def test_max_run_validation(self):
+        for bad in (0, -1, -5):
+            with self.subTest(max_run=bad):
+                with self.assertRaises(ValueError):
+                    list(mi.limit_runs('AAA', bad))
+
+    def test_max_run_non_integer(self):
+        for bad in (1.0, '1', 2.5, True, False):
+            with self.subTest(max_run=bad):
+                with self.assertRaises(ValueError):
+                    list(mi.limit_runs('AAA', bad))


### PR DESCRIPTION
Adds `limit_runs(iterable, max_run, key=None)`: yield items in order, capping each maximal run of adjacent-equal items at *max_run* occurrences and dropping the rest.

It fills the gap between `unique_justseen` (a cap of one) and doing nothing — the natural tool for de-spamming streams (repeated log lines, stuttered sensor readings) while preserving bounded repetition:

```python
>>> list(limit_runs('AAAABBBCCDAABBB', 2))
['A', 'A', 'B', 'B', 'C', 'C', 'D', 'A', 'A', 'B', 'B']
```

- Adjacency-equality follows `unique_justseen`'s model (`key` supported; original items are yielded, not keys; a value recurring after different items starts a fresh run).
- `limit_runs(iterable, 1, key)` yields exactly what `unique_justseen(iterable, key)` yields — covered by a test against a non-trivial input.
- Lazy and single-pass; works against infinite iterators.
- `max_run` must be a positive integer (bools rejected); anything else raises `ValueError`.

Registered everywhere a sibling is: `__all__`, the `.pyi` stub, `docs/api.rst` beside the unique family, and the README function table. Tests in `tests/test_more.py` in the existing unittest style; the full suite plus doctests pass.

Full disclosure: this change was implemented end-to-end by [Detent](https://github.com/AmineYagoub/detent), an autonomous-engineering tool I'm building — every step gated by this repo's own suite and independently reviewed before commit. Happy to adjust naming, semantics, or anything else to fit the library's taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
