### PR TITLE
fix `one` to respect custom error handlers

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -663,7 +663,7 @@ def one(iterable, too_short=None, too_long=None):
                 f'Expected exactly one item in iterable, but got {first!r}, '
                 f'{second!r}, and perhaps more.'
             )
-            raise too_long or ValueError(msg)
+            raise ValueError(msg)
         return first
     if too_short is not None:
         raise too_short

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -657,13 +657,17 @@ def one(iterable, too_short=None, too_long=None):
     iterator = iter(iterable)
     for first in iterator:
         for second in iterator:
+            if too_long is not None:
+                raise too_long
             msg = (
                 f'Expected exactly one item in iterable, but got {first!r}, '
                 f'{second!r}, and perhaps more.'
             )
             raise too_long or ValueError(msg)
         return first
-    raise too_short or ValueError('too few items in iterable (expected 1)')
+    if too_short is not None:
+        raise too_short
+    raise ValueError('too few items in iterable (expected 1)')
 
 
 def raise_(exception, *args):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -785,7 +785,9 @@ class OneTests(TestCase):
                 raise NotImplementedError("__repr__ is not supported")
 
         it = (BadRepr() for _ in count())
-        self.assertRaises(OverflowError, lambda: mi.one(it, too_long=OverflowError))
+        self.assertRaises(
+            OverflowError, lambda: mi.one(it, too_long=OverflowError)
+        )
 
     def test_too_long_opinionated_raisable_bool(self):
         class FalseError(Exception):
@@ -793,7 +795,9 @@ class OneTests(TestCase):
                 return False
 
         it = count()
-        self.assertRaises(FalseError, lambda: mi.one(it, too_long=FalseError()))
+        self.assertRaises(
+            FalseError, lambda: mi.one(it, too_long=FalseError())
+        )
 
     def test_too_short_opinionated_raisable_bool(self):
         class FalseError(Exception):
@@ -801,7 +805,9 @@ class OneTests(TestCase):
                 return False
 
         it = []
-        self.assertRaises(FalseError, lambda: mi.one(it, too_short=FalseError()))
+        self.assertRaises(
+            FalseError, lambda: mi.one(it, too_short=FalseError())
+        )
 
 
 class IntersperseTest(TestCase):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -779,6 +779,30 @@ class OneTests(TestCase):
             lambda: mi.one(it),
         )
 
+    def test_too_long_bad_raisable_repr(self):
+        class BadRepr:
+            def __repr__(self):
+                raise NotImplementedError("__repr__ is not supported")
+
+        it = (BadRepr() for _ in count())
+        self.assertRaises(OverflowError, lambda: mi.one(it, too_long=OverflowError))
+
+    def test_too_long_opinionated_raisable_bool(self):
+        class FalseError(Exception):
+            def __bool__(self):
+                return False
+
+        it = count()
+        self.assertRaises(FalseError, lambda: mi.one(it, too_long=FalseError()))
+
+    def test_too_short_opinionated_raisable_bool(self):
+        class FalseError(Exception):
+            def __bool__(self):
+                return False
+
+        it = []
+        self.assertRaises(FalseError, lambda: mi.one(it, too_short=FalseError()))
+
 
 class IntersperseTest(TestCase):
     """Tests for intersperse()"""


### PR DESCRIPTION
### Issue reference
resolves more-itertools/more-itertools#1240

### Changes
Fixes a bug in `one()` where custom exception handlers (`too_long` and `too_short`) were not always respected due to the use of the boolean `or` fallback. 

Specifically, this patch:
* Prevents a crash caused by eagerly evaluating the `__repr__` of elements to build the default `ValueError` message when a custom `too_long` exception has already been provided.
* Fixes an issue where custom exceptions that evaluate to `False` (via a custom `__bool__` method) would be bypassed, incorrectly raising the default `ValueError` instead. 
* Adds test coverage for both of these edge cases (items with a broken/unsupported `__repr__`, and exception classes with `__bool__` returning `False`).

### Checks and tests
Checks ran successfully

<details>
<summary>full <code>make all-checks</code> output</summary>

```
(.venv) @andjf ➜ /workspaces/more-itertools (master) $ make all-checks
python -m pip install --upgrade -r requirements/development.txt
Requirement already satisfied: coverage in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/testing.txt (line 1)) (7.16.0)
Requirement already satisfied: ruff in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/testing.txt (line 2)) (0.16.5)
Requirement already satisfied: mypy in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (2.3.1)
Requirement already satisfied: Sphinx in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/docs/requirements.txt (line 1)) (9.1.0)
Requirement already satisfied: furo>=2025.07.19 in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/docs/requirements.txt (line 2)) (2025.12.19)
Requirement already satisfied: flit<5,>=4.0.2 in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (4.0.2)
Requirement already satisfied: flit_core<5,>=4.0.2 in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/packaging.txt (line 2)) (4.0.2)
Requirement already satisfied: setuptools in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/packaging.txt (line 3)) (84.0.0)
Requirement already satisfied: twine in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (7.0.0)
Requirement already satisfied: wheel in ./.venv/lib/python3.12/site-packages (from -r /workspaces/more-itertools/requirements/packaging.txt (line 5)) (0.48.0)
Requirement already satisfied: requests in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (2.34.2)
Requirement already satisfied: docutils in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (0.22.4)
Requirement already satisfied: tomli-w in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (1.2.0)
Requirement already satisfied: pip in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (26.2.1)
Requirement already satisfied: typing_extensions>=4.6.0 in ./.venv/lib/python3.12/site-packages (from mypy->-r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (4.16.0)
Requirement already satisfied: mypy_extensions>=1.0.0 in ./.venv/lib/python3.12/site-packages (from mypy->-r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (1.1.0)
Requirement already satisfied: pathspec>=1.0.0 in ./.venv/lib/python3.12/site-packages (from mypy->-r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (1.1.1)
Requirement already satisfied: librt>=0.13.0 in ./.venv/lib/python3.12/site-packages (from mypy->-r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (0.15.0)
Requirement already satisfied: ast-serialize<1.0.0,>=0.6.0 in ./.venv/lib/python3.12/site-packages (from mypy->-r /workspaces/more-itertools/requirements/typechecks.txt (line 1)) (0.8.0)
Requirement already satisfied: sphinxcontrib-applehelp>=1.0.7 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-devhelp>=1.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-htmlhelp>=2.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.1.0)
Requirement already satisfied: sphinxcontrib-jsmath>=1.0.1 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (1.0.1)
Requirement already satisfied: sphinxcontrib-qthelp>=1.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-serializinghtml>=1.1.9 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: Jinja2>=3.1 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (3.1.6)
Requirement already satisfied: Pygments>=2.17 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.21.0)
Requirement already satisfied: snowballstemmer>=2.2 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (3.1.1)
Requirement already satisfied: babel>=2.13 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.18.0)
Requirement already satisfied: alabaster>=0.7.14 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (1.0.0)
Requirement already satisfied: imagesize>=1.3 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (2.0.1)
Requirement already satisfied: roman-numerals>=1.0.0 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (4.1.0)
Requirement already satisfied: packaging>=23.0 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (26.3)
Requirement already satisfied: beautifulsoup4 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r /workspaces/more-itertools/docs/requirements.txt (line 2)) (4.15.0)
Requirement already satisfied: sphinx-basic-ng>=1.0.0.beta2 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r /workspaces/more-itertools/docs/requirements.txt (line 2)) (1.0.0b2)
Requirement already satisfied: accessible-pygments>=0.0.5 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r /workspaces/more-itertools/docs/requirements.txt (line 2)) (0.0.5)
Requirement already satisfied: readme-renderer>=35.0 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (46.0)
Requirement already satisfied: requests-toolbelt!=0.9.0,>=0.8.0 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (1.0.0)
Requirement already satisfied: urllib3>=1.26.0 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (2.7.0)
Requirement already satisfied: keyring>=21.2.0 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (25.7.0)
Requirement already satisfied: rfc3986>=1.4.0 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (2.0.0)
Requirement already satisfied: rich>=14.3.3 in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (15.0.0)
Requirement already satisfied: id in ./.venv/lib/python3.12/site-packages (from twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (1.6.1)
Requirement already satisfied: MarkupSafe>=2.0 in ./.venv/lib/python3.12/site-packages (from Jinja2>=3.1->Sphinx->-r /workspaces/more-itertools/docs/requirements.txt (line 1)) (3.0.3)
Requirement already satisfied: SecretStorage>=3.2 in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (3.5.0)
Requirement already satisfied: jeepney>=0.4.2 in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (0.9.0)
Requirement already satisfied: jaraco.classes in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (3.4.0)
Requirement already satisfied: jaraco.functools in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (4.6.0)
Requirement already satisfied: jaraco.context in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (6.1.2)
Requirement already satisfied: nh3>=0.2.14 in ./.venv/lib/python3.12/site-packages (from readme-renderer>=35.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (0.3.7)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (3.5.1)
Requirement already satisfied: idna<4,>=2.5 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (3.19)
Requirement already satisfied: certifi>=2023.5.7 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r /workspaces/more-itertools/requirements/packaging.txt (line 1)) (2026.7.22)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.venv/lib/python3.12/site-packages (from rich>=14.3.3->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (4.2.0)
Requirement already satisfied: mdurl~=0.1 in ./.venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=14.3.3->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (0.1.2)
Requirement already satisfied: cryptography>=2.0 in ./.venv/lib/python3.12/site-packages (from SecretStorage>=3.2->keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (50.0.1)
Requirement already satisfied: cffi>=2.0.0 in ./.venv/lib/python3.12/site-packages (from cryptography>=2.0->SecretStorage>=3.2->keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (2.1.1)
Requirement already satisfied: pycparser in ./.venv/lib/python3.12/site-packages (from cffi>=2.0.0->cryptography>=2.0->SecretStorage>=3.2->keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (3.0)
Requirement already satisfied: soupsieve>=1.6.1 in ./.venv/lib/python3.12/site-packages (from beautifulsoup4->furo>=2025.07.19->-r /workspaces/more-itertools/docs/requirements.txt (line 2)) (2.9.2)
Requirement already satisfied: more-itertools in ./.venv/lib/python3.12/site-packages (from jaraco.classes->keyring>=21.2.0->twine->-r /workspaces/more-itertools/requirements/packaging.txt (line 4)) (11.1.0)
python -m pip install --editable .
Obtaining file:///workspaces/more-itertools
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: more-itertools
  Building editable for more-itertools (pyproject.toml) ... done
  Created wheel for more-itertools: filename=more_itertools-11.1.0-py3-none-any.whl size=5627 sha256=001caba49503d513ec721d855cd8957285db6d35aabfed3f5a06153bbac2a9da
  Stored in directory: /tmp/pip-ephem-wheel-cache-slm3fjd7/wheels/c7/2c/89/80226b6765c08aef1a8513e572ed46b6c43b9722d3399e0d97
Successfully built more-itertools
Installing collected packages: more-itertools
  Attempting uninstall: more-itertools
    Found existing installation: more-itertools 11.1.0
    Uninstalling more-itertools-11.1.0:
      Successfully uninstalled more-itertools-11.1.0
Successfully installed more-itertools-11.1.0
python -m pip install --upgrade -r requirements/testing.txt
Requirement already satisfied: coverage in ./.venv/lib/python3.12/site-packages (from -r requirements/testing.txt (line 1)) (7.16.0)
Requirement already satisfied: ruff in ./.venv/lib/python3.12/site-packages (from -r requirements/testing.txt (line 2)) (0.16.5)
coverage run --include="more_itertools/*.py" -m unittest
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 904 tests in 254.098s

OK
coverage report --show-missing --fail-under=99
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
more_itertools/__init__.py       3      0   100%
more_itertools/more.py        1761      0   100%
more_itertools/recipes.py      422      0   100%
----------------------------------------------------------
TOTAL                         2186      0   100%
ruff format --check .
13 files already formatted
ruff check more_itertools tests
All checks passed!
stubtest more_itertools.more more_itertools.recipes
Success: no issues found in 2 modules
python -m pip install --upgrade -r docs/requirements.txt
Requirement already satisfied: Sphinx in ./.venv/lib/python3.12/site-packages (from -r docs/requirements.txt (line 1)) (9.1.0)
Requirement already satisfied: furo>=2025.07.19 in ./.venv/lib/python3.12/site-packages (from -r docs/requirements.txt (line 2)) (2025.12.19)
Requirement already satisfied: sphinxcontrib-applehelp>=1.0.7 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-devhelp>=1.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-htmlhelp>=2.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.1.0)
Requirement already satisfied: sphinxcontrib-jsmath>=1.0.1 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (1.0.1)
Requirement already satisfied: sphinxcontrib-qthelp>=1.0.6 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: sphinxcontrib-serializinghtml>=1.1.9 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: Jinja2>=3.1 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (3.1.6)
Requirement already satisfied: Pygments>=2.17 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.21.0)
Requirement already satisfied: docutils<0.23,>=0.21 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (0.22.4)
Requirement already satisfied: snowballstemmer>=2.2 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (3.1.1)
Requirement already satisfied: babel>=2.13 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.18.0)
Requirement already satisfied: alabaster>=0.7.14 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (1.0.0)
Requirement already satisfied: imagesize>=1.3 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.0.1)
Requirement already satisfied: requests>=2.30.0 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (2.34.2)
Requirement already satisfied: roman-numerals>=1.0.0 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (4.1.0)
Requirement already satisfied: packaging>=23.0 in ./.venv/lib/python3.12/site-packages (from Sphinx->-r docs/requirements.txt (line 1)) (26.3)
Requirement already satisfied: beautifulsoup4 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r docs/requirements.txt (line 2)) (4.15.0)
Requirement already satisfied: sphinx-basic-ng>=1.0.0.beta2 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r docs/requirements.txt (line 2)) (1.0.0b2)
Requirement already satisfied: accessible-pygments>=0.0.5 in ./.venv/lib/python3.12/site-packages (from furo>=2025.07.19->-r docs/requirements.txt (line 2)) (0.0.5)
Requirement already satisfied: MarkupSafe>=2.0 in ./.venv/lib/python3.12/site-packages (from Jinja2>=3.1->Sphinx->-r docs/requirements.txt (line 1)) (3.0.3)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.venv/lib/python3.12/site-packages (from requests>=2.30.0->Sphinx->-r docs/requirements.txt (line 1)) (3.5.1)
Requirement already satisfied: idna<4,>=2.5 in ./.venv/lib/python3.12/site-packages (from requests>=2.30.0->Sphinx->-r docs/requirements.txt (line 1)) (3.19)
Requirement already satisfied: urllib3<3,>=1.26 in ./.venv/lib/python3.12/site-packages (from requests>=2.30.0->Sphinx->-r docs/requirements.txt (line 1)) (2.7.0)
Requirement already satisfied: certifi>=2023.5.7 in ./.venv/lib/python3.12/site-packages (from requests>=2.30.0->Sphinx->-r docs/requirements.txt (line 1)) (2026.7.22)
Requirement already satisfied: soupsieve>=1.6.1 in ./.venv/lib/python3.12/site-packages (from beautifulsoup4->furo>=2025.07.19->-r docs/requirements.txt (line 2)) (2.9.2)
Requirement already satisfied: typing-extensions>=4.0.0 in ./.venv/lib/python3.12/site-packages (from beautifulsoup4->furo>=2025.07.19->-r docs/requirements.txt (line 2)) (4.16.0)
sphinx-build -W -b html docs docs/_build/html
Running Sphinx v9.1.0
loading translations [en]... done
making output directory... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 6 source files that are out of date
updating environment: [new config] 6 added, 0 changed, 0 removed
reading sources... [100%] versions
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /workspaces/more-itertools/docs/_build/html/_static/language_data.js
Writing evaluated template result to /workspaces/more-itertools/docs/_build/html/_static/basic.css
Writing evaluated template result to /workspaces/more-itertools/docs/_build/html/_static/documentation_options.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [100%] versions
generating indices... genindex py-modindex done
highlighting module code... [100%] more_itertools.recipes
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in docs/_build/html.
python -m pip install --upgrade -r requirements/packaging.txt
Requirement already satisfied: flit<5,>=4.0.2 in ./.venv/lib/python3.12/site-packages (from -r requirements/packaging.txt (line 1)) (4.0.2)
Requirement already satisfied: flit_core<5,>=4.0.2 in ./.venv/lib/python3.12/site-packages (from -r requirements/packaging.txt (line 2)) (4.0.2)
Requirement already satisfied: setuptools in ./.venv/lib/python3.12/site-packages (from -r requirements/packaging.txt (line 3)) (84.0.0)
Requirement already satisfied: twine in ./.venv/lib/python3.12/site-packages (from -r requirements/packaging.txt (line 4)) (7.0.0)
Requirement already satisfied: wheel in ./.venv/lib/python3.12/site-packages (from -r requirements/packaging.txt (line 5)) (0.48.0)
Requirement already satisfied: requests in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (2.34.2)
Requirement already satisfied: docutils in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (0.22.4)
Requirement already satisfied: tomli-w in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (1.2.0)
Requirement already satisfied: pip in ./.venv/lib/python3.12/site-packages (from flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (26.2.1)
Requirement already satisfied: readme-renderer>=35.0 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (46.0)
Requirement already satisfied: requests-toolbelt!=0.9.0,>=0.8.0 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (1.0.0)
Requirement already satisfied: urllib3>=1.26.0 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (2.7.0)
Requirement already satisfied: keyring>=21.2.0 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (25.7.0)
Requirement already satisfied: rfc3986>=1.4.0 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (2.0.0)
Requirement already satisfied: rich>=14.3.3 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (15.0.0)
Requirement already satisfied: packaging>=26.1 in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (26.3)
Requirement already satisfied: id in ./.venv/lib/python3.12/site-packages (from twine->-r requirements/packaging.txt (line 4)) (1.6.1)
Requirement already satisfied: SecretStorage>=3.2 in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (3.5.0)
Requirement already satisfied: jeepney>=0.4.2 in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (0.9.0)
Requirement already satisfied: jaraco.classes in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (3.4.0)
Requirement already satisfied: jaraco.functools in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (4.6.0)
Requirement already satisfied: jaraco.context in ./.venv/lib/python3.12/site-packages (from keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (6.1.2)
Requirement already satisfied: nh3>=0.2.14 in ./.venv/lib/python3.12/site-packages (from readme-renderer>=35.0->twine->-r requirements/packaging.txt (line 4)) (0.3.7)
Requirement already satisfied: Pygments>=2.5.1 in ./.venv/lib/python3.12/site-packages (from readme-renderer>=35.0->twine->-r requirements/packaging.txt (line 4)) (2.21.0)
Requirement already satisfied: charset_normalizer<4,>=2 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (3.5.1)
Requirement already satisfied: idna<4,>=2.5 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (3.19)
Requirement already satisfied: certifi>=2023.5.7 in ./.venv/lib/python3.12/site-packages (from requests->flit<5,>=4.0.2->-r requirements/packaging.txt (line 1)) (2026.7.22)
Requirement already satisfied: markdown-it-py>=2.2.0 in ./.venv/lib/python3.12/site-packages (from rich>=14.3.3->twine->-r requirements/packaging.txt (line 4)) (4.2.0)
Requirement already satisfied: mdurl~=0.1 in ./.venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=14.3.3->twine->-r requirements/packaging.txt (line 4)) (0.1.2)
Requirement already satisfied: cryptography>=2.0 in ./.venv/lib/python3.12/site-packages (from SecretStorage>=3.2->keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (50.0.1)
Requirement already satisfied: cffi>=2.0.0 in ./.venv/lib/python3.12/site-packages (from cryptography>=2.0->SecretStorage>=3.2->keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (2.1.1)
Requirement already satisfied: pycparser in ./.venv/lib/python3.12/site-packages (from cffi>=2.0.0->cryptography>=2.0->SecretStorage>=3.2->keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (3.0)
Requirement already satisfied: more-itertools in ./.venv/lib/python3.12/site-packages (from jaraco.classes->keyring>=21.2.0->twine->-r requirements/packaging.txt (line 4)) (11.1.0)
flit build
Fetching list of valid trove classifiers                                                                                                                                                 I-flit.validate
Built sdist: dist/more_itertools-11.1.0.tar.gz                                                                                                                                         I-flit_core.sdist
Copying package file(s) from /tmp/tmpedubi4g7/more_itertools-11.1.0/more_itertools                                                                                                     I-flit_core.wheel
Writing metadata files                                                                                                                                                                 I-flit_core.wheel
Writing the record of files                                                                                                                                                            I-flit_core.wheel
Built wheel: dist/more_itertools-11.1.0-py3-none-any.whl                                                                                                                               I-flit_core.wheel
twine check dist/*
Checking dist/more_itertools-11.1.0-py3-none-any.whl: PASSED
Checking dist/more_itertools-11.1.0.tar.gz: PASSED
```
</details>