### PR TITLE
docs: Clarify output order for sortable input elements

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -755,6 +755,9 @@ def distinct_permutations(iterable, r=None):
     duplicates are not generated and thrown away. For larger input sequences
     this is much more efficient.
 
+    If the elements of the input iterable are sortable, the output tuples are
+    produced in sorted order.
+
     Duplicate permutations arise when there are duplicated elements in the
     input iterable. The number of items returned is
     `n! / (x_1! * x_2! * ... * x_n!)`, where `n` is the total number of

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -561,6 +561,17 @@ class DistinctPermutationsTests(TestCase):
         expected = list(mi.unique_everseen(permutations(iterable), key=str))
         self.assertCountEqual(actual, expected)
 
+    def test_sortable_input_produces_sorted_output(self):
+        for iterable in [
+            [4, 3, 2, 1],
+            [2, 2, 3, 1],
+        ]:
+            for r in range(len(iterable) + 1):
+                with self.subTest(iterable=iterable, r=r):
+                    actual = list(mi.distinct_permutations(iterable, r=r))
+                    expected = sorted(set(permutations(iterable, r=r)))
+                    self.assertEqual(actual, expected)
+
 
 class DerangementsTests(TestCase):
     def test_unique_values(self):


### PR DESCRIPTION
Add note about output order for sortable elements.

### Issue reference

No issue. This is a documentation-only clarification of existing behavior.

### Changes

Document that when the elements of the input iterable are sortable, distinct_permutations produces its output tuples in sorted order.

The current implementation already produces permutations in sorted order when the input elements are sortable. This is a useful property for callers and seems worth making part of the documented behavior. [`itertools.permutations`](https://docs.python.org/3/library/itertools.html#itertools.permutations) explicitly documents its corresponding ordering behavior, so I think this behavior should be documented here as well.

### Checks and tests

Documentation-only change.
