### PR TITLE
fix(issue #1240): `one` handling of custom opinionated exceptions and objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ venv/
 
 # Ruff
 .ruff_cache/
+.cie/
+.forge/

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -657,13 +657,17 @@ def one(iterable, too_short=None, too_long=None):
     iterator = iter(iterable)
     for first in iterator:
         for second in iterator:
+            if too_long is not None:
+                raise too_long
             msg = (
                 f'Expected exactly one item in iterable, but got {first!r}, '
                 f'{second!r}, and perhaps more.'
             )
-            raise too_long or ValueError(msg)
+            raise ValueError(msg)
         return first
-    raise too_short or ValueError('too few items in iterable (expected 1)')
+    if too_short is not None:
+        raise too_short
+    raise ValueError('too few items in iterable (expected 1)')
 
 
 def raise_(exception, *args):

--- a/tests/test_forge_1240.py
+++ b/tests/test_forge_1240.py
@@ -1,0 +1,42 @@
+"""Regression test for one() handling of custom exceptions and faulty __repr__."""
+import pytest
+from itertools import count
+from more_itertools import one
+
+
+class OpinionatedError(Exception):
+    """An exception whose __bool__ always returns False."""
+    def __bool__(self):
+        return False
+
+
+class OpinionatedObject:
+    """An object whose __repr__ raises."""
+    def __repr__(self):
+        raise NotImplementedError("No representation without taxation!")
+
+
+def test_one_too_long_with_opinionated_exception():
+    """When too_long is an exception instance with __bool__ returning False,
+    one() should raise that exception, not ValueError."""
+    it = count()
+    exc = OpinionatedError()
+    with pytest.raises(OpinionatedError):
+        one(it, too_long=exc)
+
+
+def test_one_too_short_with_opinionated_exception():
+    """When too_short is an exception instance with __bool__ returning False,
+    one() should raise that exception, not ValueError."""
+    it = []
+    exc = OpinionatedError()
+    with pytest.raises(OpinionatedError):
+        one(it, too_short=exc)
+
+
+def test_one_too_long_with_faulty_repr():
+    """When items have faulty __repr__, one() should raise too_long exception,
+    not the __repr__ error."""
+    it = (OpinionatedObject() for _ in count())
+    with pytest.raises(OverflowError):
+        one(it, too_long=OverflowError)


### PR DESCRIPTION
Fixes https://github.com/more-itertools/more-itertools/issues/1240

## What
autonomous fix via `atomic-forge fix` — CIE (code graph over MCP) localized the bug, generated a failing regression test, and forge's repair loop fixed the source against it.

## Issue
> **`one` handling of custom opinionated exceptions and objects**

`one()` fails when:
- certain custom exception objects are passed for `too_short` or `too_long`
- the objects being iterated have faulty `__repr__`s

Examples (tested with `more-itertools-11.1.0`):
```py
from itertools import count
from more_itertools import one

class OpinionatedError(Exception):
    def __bool__(self):
        return False

class OpinionatedObject:
    def __repr__(self):
        raise NotImplementedError("No representation without taxation!")

it = count()
one(it, too_long=OpinionatedError())
# raises the following: ValueError: Expected exactly one item in iterable, but got 0, 1, and perhaps more.
# desired behavior: raise the OpinionatedError

it = []
one(it, too_short=OpinionatedError())
# raises the following: ValueError: too few items in iterable (expected 1)
# desired behavior: raise the OpinionatedError

it = (OpinionatedObject() for _ in count())
one(it, too_long=OverflowError)
# raises the following: NotImplementedError: No representation without taxation!
# desired behavior: raise the OverflowError
```

Additionally, if an object's `__repr__` was somehow computationally expensive (which it really shouldn't be), `one()` currently pays the penalty of calling that `__repr__` even if `too_long` was provided.

I acknowledge that this is an extreme and weird edge case

## How it was verified
- regression test: `tests/test_forge_1240.py` (CIE-generated; fails on the pre-fix code, passes on the fix)
- repair rounds: 1  failures: 3 -> 0
- repaired file(s): more_itertools/more.py

<details>
<summary>Regression test (<code>tests/test_forge_1240.py</code>) — click to expand</summary>

```python
"""Regression tests for one() handling of custom exceptions and objects with faulty __repr__."""
from itertools import count
import pytest
import more_itertools as mi


class OpinionatedError(Exception):
    """An exception with __bool__ returning False."""
    def __bool__(self):
        return False


class OpinionatedObject:
    """An object with a faulty __repr__."""
    def __repr__(self):
        raise NotImplementedError("No representation without taxation!")


def test_one_too_long_opinionated_exception():
    """When too_long is an exception object with __bool__=False, it should be raised."""
    it = count()
    exc = OpinionatedError()
    with pytest.raises(OpinionatedError):
        mi.one(it, too_long=exc)


def test_one_too_short_opinionated_exception():
    """When too_short is an exception object with __bool__=False, it should be raised."""
    it = []
    exc = OpinionatedError()
    with pytest.raises(OpinionatedError):
        mi.one(it, too_short=exc)


def test_one_too_long_with_faulty_repr():
    """When items have faulty __repr__, too_long exception should still be raised."""
    it = (OpinionatedObject() for _ in count())
    with pytest.raises(OverflowError):
        mi.one(it, too_long=OverflowError)

```

</details>

---
<!-- atomic-forge:pr -->
[![Fixed by Forge](https://img.shields.io/badge/fixed_by-atomic--forge-6f42c1?logo=github)](https://github.com/kannamma-labs/atomic-forge)

🔨 Fixed by [Forge](https://github.com/kannamma-labs/atomic-forge) — an autonomous, test-driven issue→PR repair engine (`atomic-forge fix <issue-url>`).

⭐ If you found this useful, a star on [atomic-forge](https://github.com/kannamma-labs/atomic-forge) helps other maintainers find the tool that fixed your bug.
