### PR TITLE
Raise ValueError for chunked_even(n < 1)

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,6 +10,7 @@ Unreleased
 
 * Changes to existing functions:
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+    * :func:`chunked_even` now raises ``ValueError`` when *n* is less than 1
 
 11.1.0
 ------

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4591,6 +4591,9 @@ def chunked_even(iterable, n):
     [[1, 2, 3], [4, 5, 6], [7]]
 
     """
+    if n < 1:
+        raise ValueError('n must be at least 1')
+
     iterator = iter(iterable)
 
     # Initialize a buffer to process the chunks while keeping

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5253,6 +5253,18 @@ class CountableTests(TestCase):
 class ChunkedEvenTests(TestCase):
     """Tests for ``chunked_even()``"""
 
+    def test_n_less_than_one(self):
+        self.assertRaisesRegex(
+            ValueError,
+            'n must be at least 1',
+            lambda: list(mi.chunked_even('ABC', 0)),
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            'n must be at least 1',
+            lambda: list(mi.chunked_even('ABC', -1)),
+        )
+
     def test_0(self):
         self._test_finite('', 3, [])
 


### PR DESCRIPTION
`chunked_even('ABC', 0)` failed inside `islice` (`step must be a positive integer`). `divide` and `padded` already reject n < 1 with `ValueError`.