### PR TITLE
Issue 1247: Keep numeric_range consistent with the items it produces

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -2331,14 +2331,11 @@ class numeric_range(Sequence):
             return self._start > self._stop
 
     def __contains__(self, elem):
-        if self._growing:
-            if self._start <= elem < self._stop:
-                return (elem - self._start) % self._step == self._zero
-        else:
-            if self._start >= elem > self._stop:
-                return (self._start - elem) % (-self._step) == self._zero
-
-        return False
+        try:
+            self.index(elem)
+        except ValueError:
+            return False
+        return True
 
     def __eq__(self, other):
         # numeric_range object equality is intended to mirror the built-in range
@@ -2417,7 +2414,20 @@ class numeric_range(Sequence):
             return 0
         else:  # distance > 0 and step > 0: regular euclidean division
             q, r = divmod(distance, step)
-            return int(q) + int(r != self._zero)
+            n = int(q) + int(r != self._zero)
+            # The division above measures the distance to cover, but the items
+            # are produced by repeated multiplication (see `__iter__`). With
+            # inexact arithmetic the two disagree at the boundary, so settle
+            # the count against the items themselves.
+            while n and not self._before_stop(n - 1):
+                n -= 1
+            while self._before_stop(n):
+                n += 1
+            return n
+
+    def _before_stop(self, i):
+        value = self._start + i * self._step
+        return value < self._stop if self._growing else value > self._stop
 
     def __reduce__(self):
         return numeric_range, (self._start, self._stop, self._step)
@@ -2446,14 +2456,27 @@ class numeric_range(Sequence):
     def index(self, value):
         if self._growing:
             if self._start <= value < self._stop:
-                q, r = divmod(value - self._start, self._step)
-                if r == self._zero:
-                    return int(q)
+                q, _ = divmod(value - self._start, self._step)
+                return self._index_near(int(q), value)
         else:
             if self._start >= value > self._stop:
-                q, r = divmod(self._start - value, -self._step)
-                if r == self._zero:
-                    return int(q)
+                q, _ = divmod(self._start - value, -self._step)
+                return self._index_near(int(q), value)
+
+        raise ValueError(f"{value} is not in numeric range")
+
+    def _index_near(self, i, value):
+        # `i` is the quotient of the division of `value` by the step, which
+        # locates the value on the grid of items this range produces. For
+        # exact types that quotient is the index. For inexact ones (floats)
+        # it can land one short, and the remainder of the division is not a
+        # reliable membership test either: `numeric_range(0.0, 1.0, 0.1)`
+        # yields 0.30000000000000004, which leaves a non-zero remainder.
+        # So compare against the item the range actually produces there.
+        for candidate in (i, i + 1):
+            if 0 <= candidate < self._len:
+                if self._start + candidate * self._step == value:
+                    return candidate
 
         raise ValueError(f"{value} is not in numeric range")
 

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -2771,6 +2771,35 @@ class NumericRangeTests(TestCase):
                 self.assertFalse(v in r)
                 self.assertTrue(v not in r)
 
+    def test_contains_items_with_inexact_step(self):
+        # The items are produced by repeated multiplication, so with a step
+        # that has no exact float representation they do not land on an exact
+        # multiple of it. Every item must still be a member, and index() must
+        # locate it where __getitem__ puts it.
+        for args in [
+            (0.0, 1.0, 0.1),
+            (0.0, 3.0, 0.7),
+            (1.0, 0.0, -0.1),
+            (2.1, 5.1, 0.5),
+            (-1.0, 1.0, 0.25),
+        ]:
+            r = mi.numeric_range(*args)
+            for i, v in enumerate(r):
+                self.assertIn(v, r)
+                self.assertEqual(i, r.index(v))
+                self.assertEqual(v, r[i])
+                self.assertEqual(1, r.count(v))
+
+    def test_contains_non_items_with_inexact_step(self):
+        # Values the range does not produce stay out of it.
+        r = mi.numeric_range(0.0, 1.0, 0.1)
+        items = set(r)
+        for i in range(1000):
+            v = i / 1000
+            if v not in items:
+                self.assertNotIn(v, r)
+                self.assertRaises(ValueError, r.index, v)
+
     def test_eq(self):
         # numeric_range objects are equal to themselves
         range_1 = mi.numeric_range(2, 4, 1)
@@ -2980,6 +3009,28 @@ class NumericRangeTests(TestCase):
             ),
         ]:
             self.assertEqual(expected, len(mi.numeric_range(*args)))
+
+    def test_len_matches_iteration(self):
+        # len() is derived by division while the items come from repeated
+        # multiplication; the two must not disagree, or the last index reports
+        # an item the range never yields.
+        for args in [
+            # the division overshoots: len() counted an item past the stop
+            (-8.732, -13.532, -2.4),
+            (4.51, 10.375, 0.255),
+            # the division falls short: len() missed an item the range yields
+            (-69.37276490678778, -29.8339073344664, 4.942357196540172),
+            (32.50227965239458, 9.003418351482358, -1.9582384417426848),
+            (0.0, 1.0, 0.1),
+            (0.0, 3.0, 0.7),
+            (10.0, -10.0, -0.7),
+            (2.1, 5.1, 0.5),
+        ]:
+            r = mi.numeric_range(*args)
+            items = list(r)
+            self.assertEqual(len(items), len(r))
+            if items:
+                self.assertEqual(items[-1], r[len(r) - 1])
 
     def test_repr(self):
         for args, *expected in [


### PR DESCRIPTION
### Issue reference

more-itertools/more-itertools#1247

### Changes

`numeric_range` produces its items by repeated multiplication (`start + n * step`, see `__iter__` and `_get_by_index`), but derived `len()`, `__contains__` and `index()` from division by the step. With floats the two disagree:

```pycon
>>> r = numeric_range(0.0, 1.0, 0.1)
>>> r[3]
0.30000000000000004
>>> r[3] in r
False

>>> r = numeric_range(-8.732, -13.532, -2.4)
>>> len(list(r)), len(r)
(2, 3)
```

This settles all of them against the items themselves:

- `_len` still divides to get a starting count, then trims or extends it until it agrees with the values the range produces. The old formula could land one over (counting an item at or past the stop) or one under (missing an item that iteration yields).
- `index()` uses the quotient to locate the value on the grid and then confirms it by comparing against the item at that position, instead of testing the remainder for zero.
- `__contains__` defers to `index()`, and `count()` already defers to `__contains__`, so the four cannot drift apart again.

Exact types are unaffected. `Decimal`, `Fraction`, `int` and `datetime`/`timedelta` produce a zero remainder for their own items, so they resolve on the first candidate and take the same number of operations as before; the adjustment loops in `_len` do not run for them.

Both directions of the `len()` error are in the regression tests, including the harder under-count case, which needs a step whose accumulated product drifts below the divided estimate.

### Checks and tests

`ruff format --check .`, `ruff check more_itertools tests` and `stubtest more_itertools.more more_itertools.recipes` all pass. The suite is 905 tests, all passing, and `coverage report --fail-under=99` reports 100% on `more_itertools/more.py`.

I checked the new tests fail without the change: `test_contains_items_with_inexact_step` fails on membership, and `test_len_matches_iteration` fails with `AssertionError: 2 != 3`.
