### PR TITLE
Issue 1250: don't mask TypeError raised while iterating in value_chain

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4414,9 +4414,11 @@ def value_chain(*args):
             yield value
             continue
         try:
-            yield from value
+            it = iter(value)
         except TypeError:
             yield value
+        else:
+            yield from it
 
 
 def product_index(element, *iterables, repeat=1):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5074,6 +5074,28 @@ class ValueChainTests(TestCase):
         expected = [1, (2, (3,)), 'foo', ['bar', ['baz']], 'tic', 'key', obj]
         self.assertEqual(actual, expected)
 
+    def test_type_error_while_iterating(self):
+        # A TypeError raised while consuming an argument means the argument
+        # is broken, not that it is a scalar - it should propagate.
+        def gen():
+            yield 1
+            yield 2
+            raise TypeError('failure inside the iterable')
+
+        it = mi.value_chain(gen(), 3)
+        self.assertEqual([next(it), next(it)], [1, 2])
+        with self.assertRaises(TypeError):
+            next(it)
+
+    def test_type_error_from_iter(self):
+        # An object that cannot be iterated at all is still emitted as-is.
+        class NotIterable:
+            def __iter__(self):
+                raise TypeError('not iterable')
+
+        obj = NotIterable()
+        self.assertEqual(list(mi.value_chain(1, obj, [2, 3])), [1, obj, 2, 3])
+
 
 class ProductIndexTests(TestCase):
     def test_basic(self):


### PR DESCRIPTION
Addresses issue #1250.

`value_chain` classified its arguments with a `try/except TypeError` wrapped around `yield from value`. Because `yield from` consumes lazily, the guard stayed active for the whole consumption instead of only classifying the argument, so a `TypeError` raised from inside the argument was swallowed and the partially-consumed object was emitted after the items it had already produced:

```python
>>> list(value_chain(map(len, ['ab', 'cde', 5])))
[2, 3, <map object at 0x104c6e530>]
```

The `TypeError: object of type 'int' has no len()` never reached the caller, and the trailing object is exhausted, so it carries no data. `itertools.chain` and `always_iterable` both propagate on the same input.

The fix classifies with `iter()` and consumes outside the guard — the same approach `always_iterable` already uses:

```python
        try:
            it = iter(value)
        except TypeError:
            yield value
        else:
            yield from it
```

Arguments that cannot be iterated at all, including those whose `__iter__` raises `TypeError`, are still emitted as-is, so the documented behaviour is unchanged. Both existing behaviours are pinned by the new tests: one asserts the `TypeError` now propagates after the already-produced items, the other asserts the non-iterable fallback still holds.

Checks run locally: `python -m unittest` (907 tests), `ruff format --check .`, `ruff check more_itertools tests`, `stubtest more_itertools.more more_itertools.recipes`, and `coverage report` at 100%.
