### PR TITLE
Do not yield an empty list for an empty iterable when maxsplit is 0

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,6 +10,7 @@ Unreleased
 
 * Changes to existing functions:
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
+    * :func:`split_before`, :func:`split_after`, and :func:`split_when` no longer yield an empty list for an empty *iterable* when *maxsplit* is ``0``
 
 11.1.0
 ------

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1618,7 +1618,9 @@ def split_before(iterable, pred, maxsplit=-1):
         [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]]
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     buf = []
@@ -1654,7 +1656,9 @@ def split_after(iterable, pred, maxsplit=-1):
 
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     buf = []
@@ -1694,7 +1698,9 @@ def split_when(iterable, pred, maxsplit=-1):
 
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     it = iter(iterable)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1490,17 +1490,17 @@ class SplitAtTests(TestCase):
                 self.assertEqual(actual, expected)
 
     def test_maxsplit(self):
-        iterable = 'a,bb,ccc,dddd'
         separator = ','
         pred = lambda x: x == separator
 
-        for maxsplit in range(-1, 4):
-            with self.subTest(maxsplit=maxsplit):
-                it = iter(iterable)
-                result = mi.split_at(it, pred, maxsplit=maxsplit)
-                actual = [''.join(x) for x in result]
-                expected = iterable.split(separator, maxsplit)
-                self.assertEqual(actual, expected)
+        for iterable in ['a,bb,ccc,dddd', '']:
+            for maxsplit in range(-1, 4):
+                with self.subTest(iterable=iterable, maxsplit=maxsplit):
+                    it = iter(iterable)
+                    result = mi.split_at(it, pred, maxsplit=maxsplit)
+                    actual = [''.join(x) for x in result]
+                    expected = iterable.split(separator, maxsplit)
+                    self.assertEqual(actual, expected)
 
     def test_keep_separator(self):
         separator = ','
@@ -1546,9 +1546,13 @@ class SplitBeforeTest(TestCase):
         self.assertEqual(actual, expected)
 
     def test_empty_collection(self):
-        actual = list(mi.split_before([], lambda c: bool(c)))
-        expected = []
-        self.assertEqual(actual, expected)
+        for maxsplit in range(-1, 4):
+            with self.subTest(maxsplit=maxsplit):
+                actual = list(
+                    mi.split_before([], lambda c: bool(c), maxsplit=maxsplit)
+                )
+                expected = []
+                self.assertEqual(actual, expected)
 
     def test_max_split(self):
         for args, expected in [
@@ -1602,6 +1606,15 @@ class SplitAfterTest(TestCase):
         actual = list(mi.split_after('ooo', lambda c: c == 'x'))
         expected = [['o', 'o', 'o']]
         self.assertEqual(actual, expected)
+
+    def test_empty_collection(self):
+        for maxsplit in range(-1, 4):
+            with self.subTest(maxsplit=maxsplit):
+                actual = list(
+                    mi.split_after([], lambda c: bool(c), maxsplit=maxsplit)
+                )
+                expected = []
+                self.assertEqual(actual, expected)
 
     def test_max_split(self):
         for args, expected in [
@@ -1687,9 +1700,13 @@ class SplitWhenTests(TestCase):
 
     # edge cases
     def test_empty_iterable(self):
-        actual = list(mi.split_when('', lambda a, b: a != b))
-        expected = []
-        self.assertEqual(actual, expected)
+        for maxsplit in range(-1, 4):
+            with self.subTest(maxsplit=maxsplit):
+                actual = list(
+                    mi.split_when('', lambda a, b: a != b, maxsplit=maxsplit)
+                )
+                expected = []
+                self.assertEqual(actual, expected)
 
     def test_one_element(self):
         actual = list(mi.split_when('o', lambda a, b: a == b))


### PR DESCRIPTION
### Issue reference

more-itertools/more-itertools#1252

### Changes

`split_before`, `split_after` and `split_when` share a `maxsplit == 0` fast path that yields `list(iterable)` unconditionally, so an empty iterable gave `[[]]` where every other `maxsplit` gave `[]`:

```python
>>> {ms: list(mi.split_before([], lambda x: x == 0, maxsplit=ms)) for ms in (-1, 0, 1, 2)}
{-1: [], 0: [[]], 1: [], 2: []}
```

Their slow paths all return nothing for an empty iterable — `split_before`/`split_after` via `if buf:`, `split_when` via its `StopIteration` early return — and `test_empty_collection`/`test_empty_iterable` already pin `[]`, but neither passes `maxsplit`, so neither reaches the fast path. The fast path landed in f77823f as a speed shortcut, when `[[]]` was still correct here; 2e81a56 fixed the empty case a year later without reaching behind it.

`split_at` is left alone: its slow path yields the trailing empty list, matching `''.split(',', 0) == ['']`.

### Checks and tests

The `maxsplit`-less edge-case tests become loops over `maxsplit in range(-1, 4)` (adding one to `SplitAfterTest`), and `SplitAtTests.test_maxsplit` gains `''`, keeping `split_at`'s `['']` pinned to the `str.split` oracle.

Reverting `more.py` fails 3 of them. Applying the guard to `split_at` too fails `test_maxsplit` (`[] != ['']`); deleting the fast path outright fails the pre-existing `test_max_split` cases.

`make check` clean, `python -m unittest` 909 passed / 5 skipped, coverage 100%.
