### PR TITLE
split_before/split_after/split_when: make maxsplit=0 agree with other values on empty input

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -1618,7 +1618,9 @@ def split_before(iterable, pred, maxsplit=-1):
         [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]]
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     buf = []
@@ -1654,7 +1656,9 @@ def split_after(iterable, pred, maxsplit=-1):
 
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     buf = []
@@ -1694,7 +1698,9 @@ def split_when(iterable, pred, maxsplit=-1):
 
     """
     if maxsplit == 0:
-        yield list(iterable)
+        buf = list(iterable)
+        if buf:
+            yield buf
         return
 
     it = iter(iterable)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1550,6 +1550,13 @@ class SplitBeforeTest(TestCase):
         expected = []
         self.assertEqual(actual, expected)
 
+    def test_empty_collection_max_split_zero(self):
+        # maxsplit=0 took a fast path that yielded [[]] while every other
+        # maxsplit yielded [] for an empty iterable (issue #1252)
+        for maxsplit in (-1, 0, 1, 2):
+            actual = list(mi.split_before([], lambda c: bool(c), maxsplit=maxsplit))
+            self.assertEqual(actual, [])
+
     def test_max_split(self):
         for args, expected in [
             (
@@ -1587,6 +1594,13 @@ class SplitBeforeTest(TestCase):
 
 class SplitAfterTest(TestCase):
     """Tests for ``split_after()``"""
+
+    def test_empty_collection_max_split_zero(self):
+        # maxsplit=0 took a fast path that yielded [[]] while every other
+        # maxsplit yielded [] for an empty iterable (issue #1252)
+        for maxsplit in (-1, 0, 1, 2):
+            actual = list(mi.split_after([], lambda c: bool(c), maxsplit=maxsplit))
+            self.assertEqual(actual, [])
 
     def test_starts_with_sep(self):
         actual = list(mi.split_after('xooxoo', lambda c: c == 'x'))
@@ -1652,6 +1666,13 @@ class SplitWhenTests(TestCase):
     @staticmethod
     def _split_when_after(iterable, pred):
         return mi.split_when(iterable, lambda c, _: pred(c))
+
+    def test_empty_collection_max_split_zero(self):
+        # maxsplit=0 took a fast path that yielded [[]] while every other
+        # maxsplit yielded [] for an empty iterable (issue #1252)
+        for maxsplit in (-1, 0, 1, 2):
+            actual = list(mi.split_when([], lambda a, b: False, maxsplit=maxsplit))
+            self.assertEqual(actual, [])
 
     # split_before emulation
     def test_before_emulation_starts_with_sep(self):


### PR DESCRIPTION
## Summary

Fixes #1252.

With `maxsplit=0` the fast path yielded `[[]]` for an empty iterable, while every other `maxsplit` value yielded `[]` — although no split can happen either way:

```python
>>> pred = lambda x: x == 0
>>> {ms: list(mi.split_before([], pred, maxsplit=ms)) for ms in (-1, 0, 1, 2)}
{-1: [], 0: [[]], 1: [], 2: []}   # before this change
```

The three fast paths now yield nothing for empty input, matching their own slow paths and the expectations already pinned by `test_empty_collection`. `split_at` is untouched — its `[[]]` at every `maxsplit` is self-consistent and mirrors `"".split(",", 0) == [""]`.

## Changes

- `more_itertools/more.py`: `split_before`, `split_after`, `split_when` — the `maxsplit == 0` fast paths now only yield a chunk when the input is non-empty
- `tests/test_more.py`: one regression test per class asserting `[]` for empty input across `maxsplit` in `(-1, 0, 1, 2)`

## Validation

- [x] Reproduced the issue's dict on `master` before the change
- [x] After the change: all three functions return `[]` for every `maxsplit` on empty input; non-empty `maxsplit=0` behavior unchanged (`[[0, 1, 2]]` etc.)
- [x] `python -m pytest tests/ -q` — 745 passed, 21049 subtests passed
- [x] `doctest.testmod(more_itertools)` — 0 failures

## Notes

`split_at` deliberately keeps its current behavior; changing it would be a separate discussion (its `[[]]` matches `str.split` semantics).