### PR TITLE
perf(recipes): accelerate singleton combination lookups

### DIFF
--- a/more_itertools/recipes.py
+++ b/more_itertools/recipes.py
@@ -681,6 +681,8 @@ def nth_combination(iterable, r, index):
         index += c
     if not 0 <= index < c:
         raise IndexError
+    if type(r) is int and type(index) is int and r == 1:
+        return (pool[index],)
 
     result = []
     while r:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -731,6 +731,26 @@ class NthCombinationTests(TestCase):
         expected = (2, 12, 35, 126)
         self.assertEqual(actual, expected)
 
+    def test_singleton_positions_and_iterable(self):
+        iterable = (value for value in 'abc')
+        self.assertEqual(mi.nth_combination(iterable, 1, 0), ('a',))
+        self.assertEqual(tuple(iterable), ())
+        self.assertEqual(mi.nth_combination('abc', 1, 2), ('c',))
+        self.assertEqual(mi.nth_combination('abc', 1, -1), ('c',))
+
+    def test_singleton_invalid_index(self):
+        with self.assertRaises(IndexError):
+            mi.nth_combination('abc', 1, 3)
+        with self.assertRaises(IndexError):
+            mi.nth_combination('abc', 1, -4)
+
+    def test_singleton_int_subclass_fallback(self):
+        class IntSubclass(int):
+            pass
+
+        self.assertEqual(mi.nth_combination('abc', IntSubclass(1), 1), ('b',))
+        self.assertEqual(mi.nth_combination('abc', 1, IntSubclass(-1)), ('c',))
+
     def test_invalid_r(self):
         with self.assertRaises(ValueError):
             mi.nth_combination([], -1, 0)


### PR DESCRIPTION
### Changes

For `r=1`, `nth_combination` currently walks through preceding ranks even when its input is already a tuple. Select the validated item directly when `r` and the normalized index are exact integers. Materialization, bounds checks, negative-index normalization, and the generic numeric path remain in place.

On five fixed workloads with 4,096 items (three tuple positions, a list, and a fresh generator), mean median time fell from **0.20756 ms to 0.02270 ms (89.1%)**. A separate replay measured 0.02257 ms. These numbers describe the singleton workloads, not all combination sizes.

The extra guard has a small cost: the empty-result control measured 160.2 ns before and 194.2 ns after (+34.0 ns). All six controls passed the ceilings fixed from the initial qualification baseline.

[Weco research trajectory and exact source snapshots](https://dashboard.weco.ai/share/LQZ--fAgwZbzWsf_wZXiVCvvKzX2p_QU)

### Checks and tests

- Added three regressions covering singleton positions, generator exhaustion, invalid indexes, and integer subclasses.
- 911 upstream tests passed with 100% line coverage.
- All `make all-checks` stages passed, with dependencies installed through `uv`: Ruff formatting/lint, stubtest, Sphinx, Flit, and Twine.
- The separate evaluator checked 6,798 semantic cases, including 6,164 independent oracle cases, and rejected incorrect-result and source-integrity controls.

