### PR TITLE
Fix None handling in combination_with_replacement_index

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4533,7 +4533,7 @@ def combination_with_replacement_index(element, iterable):
                 break
             else:
                 k = tmp
-        if y is None:
+        if len(indexes) == l:
             break
     else:
         raise ValueError(

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5231,6 +5231,36 @@ class CombinationIndexTests(TestCase):
 
 
 class CombinationWithReplacementIndexTests(TestCase):
+    def test_none_values(self):
+        for iterable in (
+            [None, 1, 2],
+            [1, None, 2],
+            [1, 2, None],
+            [None, 1, None],
+        ):
+            for r in range(4):
+                first_index = {}
+                for index, element in enumerate(
+                    combinations_with_replacement(iterable, r)
+                ):
+                    with self.subTest(iterable=iterable, element=element):
+                        actual = mi.combination_with_replacement_index(
+                            iter(element), iter(iterable)
+                        )
+                        expected = first_index.setdefault(element, index)
+                        self.assertEqual(actual, expected)
+
+    def test_invalid_none_values(self):
+        for element, iterable in (
+            ((None,), [1, 2]),
+            ((1, None), [1, 2]),
+            ((1, None), [None, 1]),
+            ((None, 2), [1, None]),
+        ):
+            with self.subTest(element=element, iterable=iterable):
+                with self.assertRaises(ValueError):
+                    mi.combination_with_replacement_index(element, iterable)
+
     def test_r_less_than_n(self):
         iterable = 'abcdefg'
         r = 4


### PR DESCRIPTION
### Issue reference

Fixes #1257.

### Changes

`combination_with_replacement_index((None,), [1, None, 2])` currently returns `2` instead of `1`. It can also return an index when the requested `None` value is absent from the pool, rather than raising `ValueError`.

Stop scanning the pool only after all element positions have matched, instead of using `None` as an exhaustion signal. Add regressions comparing results against `itertools.combinations_with_replacement`, including `None` at different positions, repeated values, iterator inputs, and invalid combinations.

### Checks and tests

- `python -B -m unittest tests.test_more.CombinationWithReplacementIndexTests -v` — all 10 tests pass. The two new regression tests produced 14 failing subcases against the original implementation.
- Ruff lint and formatting checks pass; `git diff --check` passes.
- Tested with Python 3.12 on Windows. Full `make all-checks` was not completed; no full-suite coverage, documentation, or packaging success is claimed.
