### PR TITLE
Clarify `combination_with_replacement_index` a bit

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4516,7 +4516,7 @@ def combination_with_replacement_index(element, iterable):
     combinations with replacement of *iterable*.
     """
     element = tuple(element)
-    l = len(element)
+    r = len(element)
     pool = tuple(iterable)
     n = len(pool)
 
@@ -4535,7 +4535,7 @@ def combination_with_replacement_index(element, iterable):
     cumulative_sum = 0
     for k in range(1, n):
         cumulative_sum += occupations[k - 1]
-        j = l + n - 1 - k - cumulative_sum
+        j = (r - cumulative_sum) + (n - k) - 1
         i = n - k
         if i <= j:
             index += comb(j, i)


### PR DESCRIPTION
### Issue reference

None, though the name `l` was [actually misread](https://github.com/more-itertools/more-itertools/pull/1258#issuecomment-5583981098) during more-itertools/more-itertools#1257

### Changes

Rename easy-to-misread variable name `l`. Call it `r` instead, the name used in `itertools.combinations_with_replacement(iterable, r)`.

And rearrange the calculation of `j`, combining terms that belong together.

### Checks and tests

GitHub Actions succeeded.
