### PR TITLE
fix nonpositive item limits in constrained_batches

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -9,6 +9,7 @@ Unreleased
 ----------
 
 * Changes to existing functions:
+    * :func:`constrained_batches` now raises ``ValueError`` for a nonpositive *max_count*.
     * :func:`iter_index` was fixed to accept negative *start* and *stop* with general iterables (thanks to gaoflow)
     * :func:`split_before`, :func:`split_after`, and :func:`split_when` no longer yield an empty list for an empty *iterable* when *maxsplit* is ``0``
 

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -4938,7 +4938,7 @@ def constrained_batches(
     [(b'12345', b'123'), (b'12345678', b'1', b'1'), (b'12', b'1')]
 
     If a *max_count* is supplied, the number of items per batch is also
-    limited:
+    limited. It must be greater than zero:
 
     >>> iterable = [b'12345', b'123', b'12345678', b'1', b'1', b'12', b'1']
     >>> list(constrained_batches(iterable, 10, max_count = 2))
@@ -4952,6 +4952,8 @@ def constrained_batches(
     """
     if max_size <= 0:
         raise ValueError('maximum size must be greater than zero')
+    if max_count is not None and max_count <= 0:
+        raise ValueError('maximum count must be greater than zero')
 
     batch = []
     batch_size = 0

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6117,6 +6117,23 @@ class ConstrainedBatchesTests(TestCase):
         expected = [('1', '1'), ('12345678',), ('12345', '12345')]
         self.assertEqual(actual, expected)
 
+    def test_max_count_one(self):
+        self.assertEqual(
+            list(mi.constrained_batches(['', 'a', ''], 10, max_count=1)),
+            [('',), ('a',), ('',)],
+        )
+
+    def test_nonpositive_max_count(self):
+        for max_count in (0, -1):
+            for items in ([], ['a', 'b']):
+                with self.subTest(max_count=max_count, items=items):
+                    source = iter(items)
+                    with self.assertRaisesRegex(
+                        ValueError, 'maximum count must be greater than zero'
+                    ):
+                        list(mi.constrained_batches(source, 10, max_count))
+                    self.assertEqual(list(source), items)
+
     def test_strict(self):
         iterable = ['1', '123456789', '1']
         size = 8


### PR DESCRIPTION
### issue reference

no existing issue. this is a small input-validation fix found during source inspection. the repository's contribution guide allows trivial bug fixes without opening an issue first.

### changes

`constrained_batches(['a', 'b', 'c'], 10, max_count=0)` currently yields all three items together. negative counts are also silently ignored. reject a supplied `max_count` of zero or less with a clear `ValueError`, alongside the existing `max_size` validation.

`None` still means no item-count limit. the check runs before consuming input, including when input is empty. the docstring and changelog describe the new validation.

### checks and tests

- the regression test failed in all four zero/negative and empty/nonempty cases before the fix and passes afterward. it also checks that rejected input remains unconsumed.
- a boundary test verifies one-item batches, including empty strings.
- `make all-checks` passed on macos with python 3.13.7: 915 tests run, 5 skipped, 100% line coverage, formatting, lint, stub checks, documentation build, and package checks.
- `git diff --check` passed.

implemented and tested with openai codex.